### PR TITLE
Generate OpenAPI spec from handler annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ To run the backend server, ensure you have Go installed and set up on your machi
 go run . --config ../local-secrets/config.json
 ```
 
+After the backend is running, the API documentation is available at `http://localhost:8080/docs`.
+
+### Updating API documentation
+
+The OpenAPI description served at `/openapi.yaml` is generated from inline annotations.
+Run the following command from the `backend` directory whenever the handlers change:
+
+```bash
+go generate ./...
+```
+
+This command downloads the [`swag`](https://github.com/swaggo/swag) generator (if not already cached) and refreshes the files under `backend/docs/`.
+
 To run the frontend, navigate to the `frontend` directory and execute:
 ```bash
 npm install

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,0 +1,99 @@
+openapi: 3.0.3
+info:
+  title: Passport Issuer API
+  description: API for validating passport chip data and issuing IRMA credentials.
+  version: "1.0.0"
+servers:
+  - url: /
+paths:
+  /api/health:
+    get:
+      tags:
+        - Health
+      summary: Health check
+      responses:
+        '200':
+          description: Service health status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+  /api/start-validation:
+    post:
+      tags:
+        - Passport
+      summary: Start passport validation
+      description: Creates a validation session and returns identifiers required to continue verification.
+      responses:
+        '200':
+          description: Session identifier and nonce for validation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidatePassportResponse'
+        '400':
+          description: Invalid request
+        '405':
+          description: Method not allowed
+        '500':
+          description: Internal error
+  /api/verify-and-issue:
+    post:
+      tags:
+        - Passport
+      summary: Verify and issue passport credential
+      description: Validates the passport data and returns an IRMA issuance request once successful.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PassportValidationRequest'
+      responses:
+        '200':
+          description: JWT and IRMA server endpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PassportIssuanceResponse'
+        '400':
+          description: Invalid request
+        '405':
+          description: Method not allowed
+        '500':
+          description: Internal error
+components:
+  schemas:
+    PassportValidationRequest:
+      type: object
+      properties:
+        session_id:
+          type: string
+        nonce:
+          type: string
+        data_groups:
+          type: object
+          additionalProperties:
+            type: string
+        ef_sod:
+          type: string
+        aa_signature:
+          type: string
+          description: Active authentication signature
+    PassportIssuanceResponse:
+      type: object
+      properties:
+        jwt:
+          type: string
+        irma_server_url:
+          type: string
+    ValidatePassportResponse:
+      type: object
+      properties:
+        session_id:
+          type: string
+        nonce:
+          type: string

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,3 +1,10 @@
+// @title Passport Issuer API
+// @version 1.0
+// @description API for validating passport chip data and issuing IRMA credentials.
+// @BasePath /api
+// @schemes http https
+//
+//go:generate go run github.com/swaggo/swag/cmd/swag@v1.16.3 init --parseDependency --parseInternal --output docs --dir . --generalInfo main.go
 package main
 
 import (


### PR DESCRIPTION
## Summary
- annotate the HTTP handlers with swag metadata and serve an embedded `/openapi.yaml`
- refactor router wiring to use stateful handler methods and expose the generated Redoc page
- document the `go generate` workflow developers can run to refresh the OpenAPI files

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: Package MagickWand was not found, required by imagick)*

------
https://chatgpt.com/codex/tasks/task_b_68c7e38b1a1c832fb33d515758f7cf47