### PR TITLE
Upgraded to GMRTD 0.19.0

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
-	github.com/gmrtd/gmrtd v0.17.2
+	github.com/gmrtd/gmrtd v0.19.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/privacybydesign/irmago v0.19.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -64,8 +64,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fxamacker/cbor v1.5.1 h1:XjQWBgdmQyqimslUh5r4tUGmoqzHmBFQOImkWGi2awg=
 github.com/fxamacker/cbor v1.5.1/go.mod h1:3aPGItF174ni7dDzd6JZ206H8cmr4GDNBGpPa971zsU=
-github.com/gmrtd/gmrtd v0.17.2 h1:x3yAmO+dYm/CJAJQkdsUhONxHNlq00UmQF79o3+zjPU=
-github.com/gmrtd/gmrtd v0.17.2/go.mod h1:4ieVWyigoD4Xrj09veiV7g5N1gInVwE6+xhDN6gJrmQ=
+github.com/gmrtd/gmrtd v0.19.0 h1:she1xC56GHudHU7eSGgkQsJYhDlOYXMRStWqtOa2r10=
+github.com/gmrtd/gmrtd v0.19.0/go.mod h1:4ieVWyigoD4Xrj09veiV7g5N1gInVwE6+xhDN6gJrmQ=
 github.com/go-co-op/gocron v1.28.3 h1:swTsge6u/1Ei51b9VLMz/YTzEzWpbsk5SiR7m5fklTI=
 github.com/go-co-op/gocron v1.28.3/go.mod h1:39f6KNSGVOU1LO/ZOoZfcSxwlsJDQOKSu8erN0SH48Y=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=


### PR DESCRIPTION
## Summary
Upgraded gmrtd from v0.17.2 to v0.19.0

## Release Notes

| Version | Changes |
|---------|---------|
| **v0.17.3** | Bug fix: TLV hardening changes |
| **v0.18.0** | Feature: Updated style for gmrtd-reader output |
| **v0.19.0** | Feature: Updated NL CSCA master-list |

## Test plan
- [x] All existing tests pass