### PR TITLE
Improve SOD parsing diagnostics; bump gmrtd to v0.27.3

### DIFF
--- a/backend/document/edl/driving_licence.go
+++ b/backend/document/edl/driving_licence.go
@@ -2,6 +2,7 @@ package edl
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	mrtdDoc "go-passport-issuer/document"
 	"go-passport-issuer/models"
@@ -16,6 +17,25 @@ import (
 	"github.com/gmrtd/gmrtd/document"
 	"github.com/gmrtd/gmrtd/utils"
 )
+
+// bestEffortEDLIssuingState attempts to parse the eDL DG1 just enough to
+// surface the issuing member state for diagnostics when SOD construction
+// fails. Returns "" on any error.
+func bestEffortEDLIssuingState(dgs map[string]string) string {
+	dg1Hex, ok := dgs["DG1"]
+	if !ok {
+		return ""
+	}
+	dg1Bytes, err := hex.DecodeString(dg1Hex)
+	if err != nil {
+		return ""
+	}
+	dg1, err := ParseEDLDG1(dg1Bytes)
+	if err != nil || dg1 == nil {
+		return ""
+	}
+	return dg1.IssuingMemberState
+}
 
 func parseDgNumber(dgName string) (int, error) {
 	if !strings.HasPrefix(dgName, "DG") {
@@ -39,13 +59,35 @@ func PassiveAuthenticationEDL(data models.ValidationRequest, certPool *cms.CertP
 		return fmt.Errorf("EF_SOD is missing in the validation request")
 	}
 
-	slog.Info("Constructing EF.SOD from bytes")
-
 	var doc document.Document
 	var sodFileBytes = utils.HexToBytes(data.EFSOD)
+	sodLen, sodSha, sodHead := mrtdDoc.SodFingerprint(sodFileBytes)
+
+	slog.Info("Constructing EF.SOD from bytes",
+		"session_id", data.SessionId,
+		"data_groups", mrtdDoc.DataGroupInventory(data.DataGroups),
+		"efsod_len", sodLen,
+		"efsod_head_hex", sodHead,
+	)
+	// SHA-256 is a stable per-document identifier (privacy-sensitive); keep at DEBUG.
+	slog.Debug("SOD fingerprint",
+		"session_id", data.SessionId,
+		"efsod_sha256", sodSha,
+	)
 
 	doc.Mf.Lds1.Sod, err = document.NewSOD(sodFileBytes)
 	if err != nil {
+		slog.Error("failed to construct SOD",
+			"session_id", data.SessionId,
+			"efsod_len", sodLen,
+			"efsod_head_hex", sodHead,
+			"issuing_state_best_effort", bestEffortEDLIssuingState(data.DataGroups),
+			"error", err,
+		)
+		slog.Debug("SOD fingerprint for failed construction",
+			"session_id", data.SessionId,
+			"efsod_sha256", sodSha,
+		)
 		return fmt.Errorf("failed to create SOD: %w", err)
 	}
 
@@ -56,7 +98,10 @@ func PassiveAuthenticationEDL(data models.ValidationRequest, certPool *cms.CertP
 	}
 	hashAlgo := doc.Mf.Lds1.Sod.LdsSecurityObject.HashAlgorithm.Algorithm
 
-	slog.Info("Performing passive authentication for eDL")
+	slog.Info("Performing passive authentication for eDL",
+		"session_id", data.SessionId,
+		"issuing_member_state", bestEffortEDLIssuingState(data.DataGroups),
+	)
 	for dgName, dgHex := range data.DataGroups {
 		dgBytes := utils.HexToBytes(dgHex)
 		dgNum, err := parseDgNumber(dgName) // DgHash function requires dg number
@@ -79,7 +124,9 @@ func PassiveAuthenticationEDL(data models.ValidationRequest, certPool *cms.CertP
 		}
 	}
 
-	slog.Info("Verifying the request SOD against the certificate chain succeeded")
+	slog.Info("Verifying the request SOD against the certificate chain succeeded",
+		"session_id", data.SessionId,
+	)
 	_, err = doc.Mf.Lds1.Sod.SD.Verify(*certPool)
 	if err != nil {
 		return fmt.Errorf("SOD signature verification failed: %w", err)

--- a/backend/document/helpers.go
+++ b/backend/document/helpers.go
@@ -1,9 +1,35 @@
 package document
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"sort"
 	"time"
 )
+
+// SodFingerprint returns identifying info about an SOD byte slice for
+// triage logging: total length, SHA-256, and the hex of the first up-to-32
+// bytes (enough to see the TLV root tag, typically 0x77 for a valid SOD).
+func SodFingerprint(sod []byte) (length int, sha256Hex string, headHex string) {
+	sum := sha256.Sum256(sod)
+	head := sod
+	if len(head) > 32 {
+		head = head[:32]
+	}
+	return len(sod), hex.EncodeToString(sum[:]), hex.EncodeToString(head)
+}
+
+// DataGroupInventory returns a sorted list of "DGn(byteLen)" strings derived
+// from a hex-encoded data-group map. Useful to spot wrong-file uploads.
+func DataGroupInventory(dgs map[string]string) []string {
+	out := make([]string, 0, len(dgs))
+	for name, hexStr := range dgs {
+		out = append(out, fmt.Sprintf("%s(%d)", name, len(hexStr)/2))
+	}
+	sort.Strings(out)
+	return out
+}
 
 func BoolToYesNo(value bool) string {
 	if value {

--- a/backend/document/passport/passport.go
+++ b/backend/document/passport/passport.go
@@ -1,6 +1,7 @@
 package passport
 
 import (
+	"encoding/hex"
 	"fmt"
 	"go-passport-issuer/images"
 	"go-passport-issuer/models"
@@ -25,6 +26,25 @@ var euCountries = []string{
 	"LVA", "LTU", "LUX", "MLT", "NLD",
 	"POL", "PRT", "ROU", "SVK", "SVN",
 	"ESP", "SWE",
+}
+
+// bestEffortPassportIssuingState attempts to parse DG1 just enough to surface
+// the issuing state for diagnostics when SOD construction fails. Returns ""
+// on any error so it can be safely embedded in log lines.
+func bestEffortPassportIssuingState(dgs map[string]string) string {
+	dg1Hex, ok := dgs["DG1"]
+	if !ok {
+		return ""
+	}
+	dg1Bytes, err := hex.DecodeString(dg1Hex)
+	if err != nil {
+		return ""
+	}
+	dg1, err := document.NewDG1(dg1Bytes)
+	if err != nil || dg1 == nil {
+		return ""
+	}
+	return dg1.Mrz.IssuingState
 }
 
 // parseOptionalDataGroup parses an optional data group and logs errors gracefully
@@ -89,7 +109,10 @@ func parsePassportDGs(doc *document.Document, dataGroups map[string]string) erro
 }
 
 func PassiveAuthenticationPassport(data models.ValidationRequest, certPool cms.CertPool) (doc document.Document, err error) {
-	slog.Info("Starting passive authentication for passports")
+	slog.Info("Starting passive authentication for passports",
+		"session_id", data.SessionId,
+		"data_groups", mrtdDoc.DataGroupInventory(data.DataGroups),
+	)
 
 	if len(data.DataGroups) == 0 {
 		return document.Document{}, fmt.Errorf("no data groups found")
@@ -99,11 +122,33 @@ func PassiveAuthenticationPassport(data models.ValidationRequest, certPool cms.C
 		return document.Document{}, fmt.Errorf("EF_SOD is missing in the validation request")
 	}
 
-	slog.Info("Constructing document from data groups")
-
 	var sodFileBytes = utils.HexToBytes(data.EFSOD)
+	sodLen, sodSha, sodHead := mrtdDoc.SodFingerprint(sodFileBytes)
+
+	slog.Info("Constructing document from data groups",
+		"session_id", data.SessionId,
+		"efsod_len", sodLen,
+		"efsod_head_hex", sodHead,
+	)
+	// SHA-256 is a stable per-document identifier (privacy-sensitive); keep at DEBUG.
+	slog.Debug("SOD fingerprint",
+		"session_id", data.SessionId,
+		"efsod_sha256", sodSha,
+	)
+
 	doc.Mf.Lds1.Sod, err = document.NewSOD(sodFileBytes)
 	if err != nil {
+		slog.Error("failed to construct SOD",
+			"session_id", data.SessionId,
+			"efsod_len", sodLen,
+			"efsod_head_hex", sodHead,
+			"issuing_state_best_effort", bestEffortPassportIssuingState(data.DataGroups),
+			"error", err,
+		)
+		slog.Debug("SOD fingerprint for failed construction",
+			"session_id", data.SessionId,
+			"efsod_sha256", sodSha,
+		)
 		return document.Document{}, fmt.Errorf("failed to create SOD: %w", err)
 	}
 
@@ -112,7 +157,10 @@ func PassiveAuthenticationPassport(data models.ValidationRequest, certPool cms.C
 	if err != nil {
 		return document.Document{}, fmt.Errorf("failed to parse passport DGs: %w", err)
 	}
-	slog.Info("Starting passive authentication for passport", "issuing_state", doc.Mf.Lds1.Dg1.Mrz.IssuingState)
+	slog.Info("Starting passive authentication for passport",
+		"session_id", data.SessionId,
+		"issuing_state", doc.Mf.Lds1.Dg1.Mrz.IssuingState,
+	)
 
 	res, err := passiveauth.PassiveAuth(&doc, certPool)
 	if err != nil {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,7 +3,7 @@ module go-passport-issuer
 go 1.25.0
 
 require (
-	github.com/gmrtd/gmrtd v0.22.1
+	github.com/gmrtd/gmrtd v0.27.3
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/privacybydesign/irmago v0.19.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -70,8 +70,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fxamacker/cbor v1.5.1 h1:XjQWBgdmQyqimslUh5r4tUGmoqzHmBFQOImkWGi2awg=
 github.com/fxamacker/cbor v1.5.1/go.mod h1:3aPGItF174ni7dDzd6JZ206H8cmr4GDNBGpPa971zsU=
-github.com/gmrtd/gmrtd v0.22.1 h1:Y4IrHwOjohOH3cNZAIgWxJQmicC4a6Z6efsB5kea0mg=
-github.com/gmrtd/gmrtd v0.22.1/go.mod h1:Rk4GiuOkOYLokePAN1FoSjDpLcsEIoCuWZhrBuIIsaE=
+github.com/gmrtd/gmrtd v0.27.3 h1:YvthpN7g6WfB3q2RBxzg/gmAYACkW0D8gyoO1EEQb7M=
+github.com/gmrtd/gmrtd v0.27.3/go.mod h1:Rk4GiuOkOYLokePAN1FoSjDpLcsEIoCuWZhrBuIIsaE=
 github.com/go-co-op/gocron v1.28.3 h1:swTsge6u/1Ei51b9VLMz/YTzEzWpbsk5SiR7m5fklTI=
 github.com/go-co-op/gocron v1.28.3/go.mod h1:39f6KNSGVOU1LO/ZOoZfcSxwlsJDQOKSu8erN0SH48Y=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=

--- a/backend/server.go
+++ b/backend/server.go
@@ -218,11 +218,13 @@ func handleVerifyDrivingLicence(state *ServerState, w http.ResponseWriter, r *ht
 		return
 	}
 
-	slog.Info("Received request to verify driving license")
+	const endpoint = "verify-driving-licence"
+	slog.Info("Received request", "endpoint", endpoint)
 
 	doc, request, activeRes, err := VerifyDrivingLicenceRequest(r, state)
 	if err != nil {
-		respondWithErr(w, http.StatusBadRequest, "invalid request", "failed to verify driving license", err)
+		respondWithErr(w, http.StatusBadRequest, "invalid request", "failed to verify driving license", err,
+			"endpoint", endpoint, "session_id", request.SessionId)
 		return
 	}
 
@@ -261,11 +263,13 @@ func handleIssueEDL(state *ServerState, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	slog.Info("Received request to verify and issue driving licence")
+	const endpoint = "issue-driving-licence"
+	slog.Info("Received request", "endpoint", endpoint)
 	doc, request, activeRes, err := VerifyDrivingLicenceRequest(r, state)
 
 	if err != nil {
-		respondWithErr(w, http.StatusBadRequest, "invalid request", "failed to verify driving licence", err)
+		respondWithErr(w, http.StatusBadRequest, "invalid request", "failed to verify driving licence", err,
+			"endpoint", endpoint, "session_id", request.SessionId)
 		return
 	}
 
@@ -313,11 +317,13 @@ func handleVerifyPassport(state *ServerState, w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	slog.Info("Received request to do verify a passport readout")
+	const endpoint = "verify-passport"
+	slog.Info("Received request", "endpoint", endpoint)
 
 	doc, activeAuth, request, err := VerifyPassportRequest(r, state)
 	if err != nil {
-		respondWithErr(w, http.StatusBadRequest, "invalid request", ERR_PASSPORT_VERIFICATION, err)
+		respondWithErr(w, http.StatusBadRequest, "invalid request", ERR_PASSPORT_VERIFICATION, err,
+			"endpoint", endpoint, "session_id", request.SessionId)
 		return
 	}
 
@@ -364,11 +370,13 @@ func handleIssueIdCard(state *ServerState, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	slog.Info("Received request to verify and issue id card")
+	const endpoint = "issue-id-card"
+	slog.Info("Received request", "endpoint", endpoint)
 
 	doc, activeAuth, request, err := VerifyPassportRequest(r, state)
 	if err != nil {
-		respondWithErr(w, http.StatusBadRequest, "invalid request", ERR_PASSPORT_VERIFICATION, err)
+		respondWithErr(w, http.StatusBadRequest, "invalid request", ERR_PASSPORT_VERIFICATION, err,
+			"endpoint", endpoint, "session_id", request.SessionId)
 		return
 	}
 
@@ -416,11 +424,13 @@ func handleIssuePassport(state *ServerState, w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	slog.Info("Received request to verify and issue passport")
+	const endpoint = "issue-passport"
+	slog.Info("Received request", "endpoint", endpoint)
 
 	doc, activeAuth, request, err := VerifyPassportRequest(r, state)
 	if err != nil {
-		respondWithErr(w, http.StatusBadRequest, "invalid request", ERR_PASSPORT_VERIFICATION, err)
+		respondWithErr(w, http.StatusBadRequest, "invalid request", ERR_PASSPORT_VERIFICATION, err,
+			"endpoint", endpoint, "session_id", request.SessionId)
 		return
 	}
 
@@ -642,8 +652,10 @@ func GenerateNonce(i int) (string, error) {
 	return hexString, nil
 }
 
-func respondWithErr(w http.ResponseWriter, code int, responseBody string, logMsg string, e error) {
-	slog.Error(logMsg, "error", e, "status_code", code, "response_body", responseBody)
+func respondWithErr(w http.ResponseWriter, code int, responseBody string, logMsg string, e error, extras ...any) {
+	args := []any{"error", e, "status_code", code, "response_body", responseBody}
+	args = append(args, extras...)
+	slog.Error(logMsg, args...)
 	w.WriteHeader(code)
 	if _, err := w.Write([]byte(responseBody)); err != nil {
 		slog.Error("failed to write body to http response", "error", err)


### PR DESCRIPTION
## Summary

Two changes, motivated by a `passive authentication failed: failed to create SOD: [NewSOD] Incorrect ContentType (got:1.3.27.1.1.1)` error seen in production with no surrounding context to diagnose it from.

### 1. SOD parsing diagnostics

The original failure log only carried the gmrtd error string and a generic `status_code=400`. With no correlation ID, no document fingerprint, and no issuing state, it was impossible to tell whether the client had hit the wrong endpoint with eDL data or the issuer was genuinely non-conformant.

- Each verify/issue handler now declares its endpoint name, logs it on entry, and passes `endpoint` + `session_id` into the error path via a variadic extension to `respondWithErr`.
- `PassiveAuthenticationPassport` and `PassiveAuthenticationEDL` log a fingerprint of the submitted SOD (length, first 32 bytes, data-group inventory) before `NewSOD` runs.
- On `NewSOD` failure both paths emit a dedicated `slog.Error` that includes a best-effort issuing state parsed from DG1 (so the country is captured even though full DG1 parsing hasn't happened yet).
- The SHA-256 of the SOD is logged at `DEBUG` only — it is a stable pseudonymous identifier for a specific document, so it stays out of production INFO/ERROR streams.
- Two small helpers (`SodFingerprint`, `DataGroupInventory`) live in the shared `document` package so both flows reuse them.

### 2. gmrtd bump

`github.com/gmrtd/gmrtd` v0.22.1 → v0.27.3. Build clean, full test suite green. (Note: the eContentType allowlist in `isValidEContentType` is unchanged across these versions, so this bump does not by itself fix the `1.3.27.1.1.1` rejection — the new logging is what'll tell us which case we're hitting next time.)