### PR TITLE
Add ECDSA active-auth hash diagnostic on failure

### DIFF
--- a/backend/document/aa_debug.go
+++ b/backend/document/aa_debug.go
@@ -1,0 +1,142 @@
+package document
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"encoding/asn1"
+	"log/slog"
+	"math/big"
+
+	"github.com/gmrtd/gmrtd/cms"
+	"github.com/gmrtd/gmrtd/cryptoutils"
+)
+
+// LogAATryAlternateHashes is a forensic-only helper used after gmrtd's
+// ValidateActiveAuthSignature has rejected an ECDSA signature. It does NOT
+// change the authentication result — it only tries every reasonable
+// (hash, signature-encoding) combination against the provided public key
+// and logs which combination, if any, verifies.
+//
+// This is the decisive diagnostic for two failure classes:
+//   - chip uses a non-heuristic hash (e.g. SHA-256 over a P-384 key on
+//     Portuguese cards that ship without a DG14 ActiveAuthenticationInfo)
+//   - the signature was tampered with / DG15 mismatch (no combination works)
+//
+// Inputs are session-scoped and not durable PII; the public key, nonce and
+// signature only identify this one challenge-response exchange. The
+// per-combination attempts log at DEBUG; a positive match logs at INFO
+// because it is actionable.
+func LogAATryAlternateHashes(sessionId string, subjectPublicKeyInfoBytes, sig, nonce []byte) {
+	if len(subjectPublicKeyInfoBytes) == 0 || len(sig) == 0 || len(nonce) == 0 {
+		return
+	}
+
+	spki, err := cms.Asn1decodeSubjectPublicKeyInfo(subjectPublicKeyInfoBytes)
+	if err != nil {
+		slog.Debug("AA diagnostic: SPKI decode failed", "session_id", sessionId, "error", err)
+		return
+	}
+	if !spki.IsEC() {
+		// RSA AA takes a completely different verification path; not in scope here.
+		return
+	}
+
+	curve, ecPoint, err := spki.EcCurveAndPubKey(true)
+	if err != nil {
+		slog.Debug("AA diagnostic: EC pubkey decode failed", "session_id", sessionId, "error", err)
+		return
+	}
+	pub := &ecdsa.PublicKey{Curve: *curve, X: ecPoint.X, Y: ecPoint.Y}
+
+	type parsedSig struct {
+		format string
+		r, s   *big.Int
+	}
+	var sigs []parsedSig
+	if r, s, ok := parsePlainEcdsaSig(sig); ok {
+		sigs = append(sigs, parsedSig{"plain", r, s})
+	}
+	if r, s, ok := parseDEREcdsaSig(sig); ok {
+		sigs = append(sigs, parsedSig{"DER", r, s})
+	}
+	if len(sigs) == 0 {
+		slog.Info("AA diagnostic: no parseable signature encoding",
+			"session_id", sessionId,
+			"sig_len", len(sig),
+			"curve", pub.Params().Name,
+		)
+		return
+	}
+
+	candidates := []struct {
+		name string
+		alg  crypto.Hash
+	}{
+		{"SHA-224", crypto.SHA224},
+		{"SHA-256", crypto.SHA256},
+		{"SHA-384", crypto.SHA384},
+		{"SHA-512", crypto.SHA512},
+	}
+
+	matched := false
+	for _, p := range sigs {
+		for _, c := range candidates {
+			hash := cryptoutils.CryptoHash(c.alg, nonce)
+			if ecdsa.Verify(pub, hash, p.r, p.s) {
+				slog.Info("AA diagnostic: alternate hash/encoding verified",
+					"session_id", sessionId,
+					"hash", c.name,
+					"sig_format", p.format,
+					"curve", pub.Params().Name,
+				)
+				matched = true
+			} else {
+				slog.Debug("AA diagnostic: combination did not verify",
+					"session_id", sessionId,
+					"hash", c.name,
+					"sig_format", p.format,
+				)
+			}
+		}
+	}
+	if !matched {
+		slog.Info("AA diagnostic: no hash/encoding combination verified",
+			"session_id", sessionId,
+			"curve", pub.Params().Name,
+			"sig_len", len(sig),
+			"nonce_len", len(nonce),
+		)
+	}
+}
+
+// parsePlainEcdsaSig parses a fixed-length r||s ECDSA signature.
+func parsePlainEcdsaSig(b []byte) (r, s *big.Int, ok bool) {
+	if len(b) < 2 || len(b)%2 != 0 {
+		return nil, nil, false
+	}
+	half := len(b) / 2
+	r = new(big.Int).SetBytes(b[:half])
+	s = new(big.Int).SetBytes(b[half:])
+	if r.Sign() <= 0 || s.Sign() <= 0 {
+		return nil, nil, false
+	}
+	return r, s, true
+}
+
+// parseDEREcdsaSig parses an ASN.1/DER SEQUENCE { r INTEGER, s INTEGER }.
+// Trailing bytes are tolerated; gmrtd's own parser is similarly lenient.
+func parseDEREcdsaSig(b []byte) (r, s *big.Int, ok bool) {
+	if len(b) == 0 || b[0] != 0x30 {
+		return nil, nil, false
+	}
+	var sig struct {
+		R, S *big.Int
+	}
+	if _, err := asn1.Unmarshal(b, &sig); err != nil {
+		return nil, nil, false
+	}
+	if sig.R == nil || sig.S == nil || sig.R.Sign() <= 0 || sig.S.Sign() <= 0 {
+		return nil, nil, false
+	}
+	return sig.R, sig.S, true
+}

--- a/backend/document/edl/driving_licence.go
+++ b/backend/document/edl/driving_licence.go
@@ -165,11 +165,13 @@ func ActiveAuthenticationEDL(data models.ValidationRequest) (result bool, err er
 
 	res, err := activeAuth.ValidateActiveAuthSignature(dgDg15, aaSigBytes, nonceBytes)
 	if err != nil {
+		mrtdDoc.LogAATryAlternateHashes(data.SessionId, pubKeyBytes, aaSigBytes, nonceBytes)
 		return false, fmt.Errorf("failed to validate active authentication signature: %w", err)
 	}
 	// Defensive check: In the current gmrtd implementation, if err is nil, then res.Success is always true.
 	// However, we keep this check for safety and future compatibility.
 	if !res.Success {
+		mrtdDoc.LogAATryAlternateHashes(data.SessionId, pubKeyBytes, aaSigBytes, nonceBytes)
 		return false, fmt.Errorf("active authentication failed")
 	}
 

--- a/backend/document/passport/passport.go
+++ b/backend/document/passport/passport.go
@@ -180,18 +180,22 @@ func ActiveAuthentication(data models.ValidationRequest, doc document.Document) 
 		return false, nil
 	}
 
-	slog.Info("Starting active authentication signature validation")
+	slog.Info("Starting active authentication signature validation",
+		"session_id", data.SessionId,
+	)
 
 	aaSigBytes := utils.HexToBytes(data.ActiveAuthSignature)
 	nonceBytes := utils.HexToBytes(data.Nonce)
 
 	res, err := activeAuth.ValidateActiveAuthSignature(doc.Mf.Lds1.Dg15, aaSigBytes, nonceBytes)
 	if err != nil {
+		mrtdDoc.LogAATryAlternateHashes(data.SessionId, doc.Mf.Lds1.Dg15.SubjectPublicKeyInfoBytes, aaSigBytes, nonceBytes)
 		return false, fmt.Errorf("failed to validate active authentication signature: %w", err)
 	}
 	// Defensive check: In the current gmrtd implementation, if err is nil, then res.Success is always true.
 	// However, we keep this check for safety and future compatibility.
 	if !res.Success {
+		mrtdDoc.LogAATryAlternateHashes(data.SessionId, doc.Mf.Lds1.Dg15.SubjectPublicKeyInfoBytes, aaSigBytes, nonceBytes)
 		return false, fmt.Errorf("active authentication failed")
 	}
 	return true, nil


### PR DESCRIPTION
## Summary

Follow-up to #97. Adds a forensic-only diagnostic that runs after gmrtd's `ValidateActiveAuthSignature` rejects an ECDSA Active Authentication signature.

### Motivation

In a recent production failure (Portuguese travel document, AA key on P-384) gmrtd rejected an AA signature with `did not verify with hash: SHA-384`. Passive auth succeeded against the trusted CSCA chain, the cert chain, DG hashes, signedData verify — all clean. The client (`vcmrtd`) was confirmed to hex-decode the nonce correctly and pass the chip's signature through unmodified.

That leaves two plausible causes:
1. The chip uses a non-heuristic hash pairing (e.g. SHA-256 over a P-384 key). gmrtd derives the hash purely from curve size and has no DG14 `ActiveAuthenticationInfo` to consult in this passport.
2. Genuine DG15 / signature mismatch.

This PR distinguishes the two on the next occurrence.

### Behavior

`mrtdDoc.LogAATryAlternateHashes` is invoked from both `passport.ActiveAuthentication` and `edl.ActiveAuthenticationEDL` on any AA failure (error or `res.Success == false`):

- Decodes the EC public key from the SubjectPublicKeyInfo bytes (DG15 for passports, DG13-derived for eDL). Returns silently if non-EC.
- Parses the signature as both plain `r||s` and DER.
- Cross-multiplies against `SHA-224 / 256 / 384 / 512` and tries `ecdsa.Verify`.
- Emits a single `INFO` line if any combination verifies (`alternate hash/encoding verified` with hash, sig_format, curve) or on exhaustion.
- Per-combination noise stays at `DEBUG`.
- The authentication verdict is unchanged — this only observes.

### Decision rule for the next failure

- INFO line with `hash=SHA-256 sig_format=plain curve=P-384` → chip-quirk confirmed; fix is to override the heuristic locally or upstream to gmrtd.
- INFO line "no hash/encoding combination verified" → DG15 mismatch or genuinely bad signature; investigation moves to the client side.