### PR TITLE
Bump deprecated GitHub Actions (fix delivery CI: stale grype DB)

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check whether this event is the HEAD of main
         continue-on-error: true
@@ -31,7 +31,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -40,17 +40,17 @@ jobs:
             type=ref,event=branch,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build container and export to local Docker
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           load: true
@@ -61,7 +61,7 @@ jobs:
             TURNSTILE_SITE_KEY=${{ secrets.TURNSTILE_SITE_KEY }}
 
       - name: Scan Image
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v6
         id: scan
         with:
           image: local/go-passport-issuer:scan
@@ -77,7 +77,7 @@ jobs:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
       - name: Push image to GitHub Container Registry
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         if: ${{ github.event_name == 'release' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         with:
           push: true

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -15,7 +15,7 @@ jobs:
     build-frontend:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
 
         - uses: actions/setup-node@v4
           with:
@@ -34,7 +34,7 @@ jobs:
     analyze-go:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: actions/setup-go@v5
           with:
             go-version: '1.25'
@@ -55,11 +55,11 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Docker meta
           id: meta
-          uses: docker/metadata-action@v5
+          uses: docker/metadata-action@v6
           with:
             images: ghcr.io/${{ github.repository }}
             tags: |
@@ -67,7 +67,7 @@ jobs:
               type=raw,value=edge
 
         - name: Login to GitHub Container Registry
-          uses: docker/login-action@v3
+          uses: docker/login-action@v4
           with:
             registry: ghcr.io
             username: ${{ github.actor }}
@@ -101,25 +101,25 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Docker meta
           id: meta
-          uses: docker/metadata-action@v5
+          uses: docker/metadata-action@v6
           with:
             images: ghcr.io/${{ github.repository }}
             tags: |
               type=semver,pattern={{major}}.{{minor}}.{{patch}}
               type=raw,value=edge
         - name: Login to GitHub Container Registry
-          uses: docker/login-action@v3
+          uses: docker/login-action@v4
           with:
             registry: ghcr.io
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Build container
-          uses: docker/build-push-action@v5
+          uses: docker/build-push-action@v6
           with:
             context: .
             push: false


### PR DESCRIPTION
## Summary
The `Delivery` workflow has been failing on releases because `anchore/scan-action@v3` pins an old `grype` that only reads Grype's v5 vulnerability database. Anchore stopped publishing fresh v5 builds, so every scan now downloads a stale DB (~9 weeks old), aborts with `db could not be loaded`, and the empty SARIF then breaks the upload step.

Bumping `anchore/scan-action` to v6 (current grype + v6 DB) fixes the root cause. Also bumping the other actions flagged by GitHub's Node.js 20 deprecation warning to their current Node 24-compatible majors.

## Changes
- `anchore/scan-action` v3 -> v6 (fixes the failing scan)
- `actions/checkout` v4 -> v5
- `docker/metadata-action` v5 -> v6
- `docker/setup-buildx-action` v3 -> v4
- `docker/login-action` v3 -> v4
- `docker/build-push-action` v5 -> v6

Left alone (not flagged): `actions/setup-node@v4`, `actions/setup-go@v5`, `codecov/codecov-action@v4`.