### PR TITLE
ci: bump codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -87,7 +87,7 @@ jobs:
               passport-issuer-tests
 
         - name: Upload coverage to Codecov
-          uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+          uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
           with:
             files: coverage/coverage.out
             flags: backend


### PR DESCRIPTION
The pinned `codecov-action@v6.0.1` fails GPG signature verification of the Codecov CLI after Codecov rotated their signing key, breaking CI on all branches:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
```

`v7.0.0` fixes the public-key fetch. Commit-pinned to `fb8b358`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)