### PR TITLE
docs: add NLnet funding section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,10 @@ export CGO_CFLAGS_ALLOW="-Xpreprocessor"
 brew list imagemagick@6
 pkg-config --cflags --libs MagickWand
 ```
+
+## Funding
+
+This project received funding through [NGI0 Commons Fund](https://nlnet.nl/commonsfund), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more at the [NLnet project page](https://nlnet.nl/project/Yivi-AgeVerification).
+
+[<img src="https://nlnet.nl/logo/banner.png" alt="NLnet foundation logo" width="20%" />](https://nlnet.nl)
+[<img src="https://nlnet.nl/image/logos/NGI0_tag.svg" alt="NGI Zero Logo" width="20%" />](https://nlnet.nl/commonsfund)


### PR DESCRIPTION
Adds a Funding section to the README acknowledging support from the NGI0 Commons Fund / NLnet and the European Commission's Next Generation Internet program.