### PR TITLE
feat: face verification session and gated issuance for all MRTDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,19 +88,45 @@ Add a `face_verification` block to enable it:
   "face_verification": {
     "url": "https://face.example.com",
     "verifier_id": "passport-issuer",
-    "callback_url": "https://issuer.example.com/face/callback",
-    "timeout_seconds": 10
+    "callback_url": "https://issuer.example.com/api/face/callback",
+    "timeout_seconds": 10,
+    "require_face_for_issuance": true
   }
 }
 ```
 
 - `url` — base URL of the face verification service (the configurable endpoint). Leave empty to disable.
 - `verifier_id` — identifier of this issuer as known to the face service (defaults to `passport-issuer`).
-- `callback_url` — optional URL the face service calls with the signed result.
+- `callback_url` — URL the face service calls with the signed result. Point it at the issuer's
+  `POST /api/face/callback` route.
 - `timeout_seconds` — optional HTTP timeout (defaults to 10).
+- `require_face_for_issuance` — optional; defaults to `true` when `url` is set. When `true`, issuance of
+  all document types (passport, ID card, driving licence) is **gated** on a successful face verification.
+  Set `false` to run face verification as advisory only (the session is started and the result surfaced,
+  but issuance is not blocked).
 
 The `binding_secret` returned by the face service is used to authenticate result
 callbacks and is intentionally never exposed in the validation response.
+
+#### Gated issuance flow
+
+When face verification is required, the full flow is:
+
+1. `POST /api/start-validation` → `{ session_id, nonce }`.
+2. `POST /api/verify-passport` (or `/api/verify-driving-licence`) performs passive + active authentication
+   and, on success, starts a face session bound to the chip's portrait — **DG2** for passports/ID cards,
+   **DG6** for driving licences — returning it as `face_session`. The validation session is **kept** (not
+   consumed) so it can be reused by issuance.
+3. The wallet streams to the face service; on completion the face service POSTs a signed result to
+   `callback_url` (`POST /api/face/callback`), authenticated by `HMAC-SHA256(binding_secret, …)`.
+4. `POST /api/issue-passport` (or `/api/issue-id-card`, `/api/issue-driving-licence`) with the
+   `face_session_id` from step 2 issues the credential only when **both** authentication and face
+   verification succeeded, and the request's portrait data group hashes to the same portrait the face
+   session was created with. If the result has not yet arrived the issuer polls the face service's status
+   endpoint; while still pending it responds `428` with `face:pending`. A failed or missing verdict yields
+   `403` (`face:failed` / `face:required` / `face:mismatch`).
+
+See [`docs/verification-flow-contracts.md`](docs/verification-flow-contracts.md) for the full contract.
 
 ### Running the application
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@ It should look like this:
 ```
 The `jwt_private_key_path` should point to a valid RSA private key in PEM format, which is used to sign JWT tokens for the IRMA server.
 
+#### Face verification (optional)
+
+The issuer can optionally start a session at a
+[face verification service](https://github.com/privacybydesign/face-verification-service)
+when validating a passport. When configured, `POST /api/verify-passport` creates
+a session bound to the chip's DG2 portrait and returns it as a `face_session`
+field in the response. The integration is **off by default**: when no `url` is set
+the behaviour is unchanged. Add a `face_verification` block to enable it:
+
+```json
+{
+  "face_verification": {
+    "url": "https://face.example.com",
+    "verifier_id": "passport-issuer",
+    "callback_url": "https://issuer.example.com/face/callback",
+    "timeout_seconds": 10
+  }
+}
+```
+
+- `url` — base URL of the face verification service (the configurable endpoint). Leave empty to disable.
+- `verifier_id` — identifier of this issuer as known to the face service (defaults to `passport-issuer`).
+- `callback_url` — optional URL the face service calls with the signed result.
+- `timeout_seconds` — optional HTTP timeout (defaults to 10).
+
+The `binding_secret` returned by the face service is used to authenticate result
+callbacks and is intentionally never exposed in the validation response.
+
 ### Running the application
 
 #### Local Development (without Docker)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,14 @@ The issuer can optionally start a session at a
 when validating a passport. When configured, `POST /api/verify-passport` creates
 a session bound to the chip's DG2 portrait and returns it as a `face_session`
 field in the response. The integration is **off by default**: when no `url` is set
-the behaviour is unchanged. Add a `face_verification` block to enable it:
+the behaviour is unchanged.
+
+The reference photo sent to the face service is the **original, unmodified DG2
+bytes** (base64-encoded), not a re-encoded image. The binding key is derived from
+`SHA256(reference_photo)`, and the mobile app derives the same key over the raw
+DG2 it read from the chip — so both sides must hash identical bytes.
+
+Add a `face_verification` block to enable it:
 
 ```json
 {

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -299,6 +299,27 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "main.FaceSession": {
+            "type": "object",
+            "properties": {
+                "binding_key_ready": {
+                    "description": "True when a reference portrait was supplied at creation (always true here).",
+                    "type": "boolean"
+                },
+                "face_session_id": {
+                    "description": "Identifier used in every subsequent face verification call.",
+                    "type": "string"
+                },
+                "face_session_token": {
+                    "description": "Base64url-encoded blob the wallet uses to learn the session id and stream URL.",
+                    "type": "string"
+                },
+                "websocket_url": {
+                    "description": "WebSocket endpoint the client streams camera frames to.",
+                    "type": "string"
+                }
+            }
+        },
         "main.HealthResponse": {
             "type": "object",
             "properties": {
@@ -351,6 +372,14 @@ const docTemplate = `{
                     "description": "True if passive authentication (signature verification) succeeded",
                     "type": "boolean",
                     "example": true
+                },
+                "face_session": {
+                    "description": "Optional face verification session, present only when the face verification\nintegration is configured and a session was created from the DG2 portrait.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/main.FaceSession"
+                        }
+                    ]
                 },
                 "is_expired": {
                     "description": "True if the document has expired",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -292,6 +292,27 @@
         }
     },
     "definitions": {
+        "main.FaceSession": {
+            "type": "object",
+            "properties": {
+                "binding_key_ready": {
+                    "description": "True when a reference portrait was supplied at creation (always true here).",
+                    "type": "boolean"
+                },
+                "face_session_id": {
+                    "description": "Identifier used in every subsequent face verification call.",
+                    "type": "string"
+                },
+                "face_session_token": {
+                    "description": "Base64url-encoded blob the wallet uses to learn the session id and stream URL.",
+                    "type": "string"
+                },
+                "websocket_url": {
+                    "description": "WebSocket endpoint the client streams camera frames to.",
+                    "type": "string"
+                }
+            }
+        },
         "main.HealthResponse": {
             "type": "object",
             "properties": {
@@ -344,6 +365,14 @@
                     "description": "True if passive authentication (signature verification) succeeded",
                     "type": "boolean",
                     "example": true
+                },
+                "face_session": {
+                    "description": "Optional face verification session, present only when the face verification\nintegration is configured and a session was created from the DG2 portrait.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/main.FaceSession"
+                        }
+                    ]
                 },
                 "is_expired": {
                     "description": "True if the document has expired",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,5 +1,22 @@
 basePath: /api
 definitions:
+  main.FaceSession:
+    properties:
+      binding_key_ready:
+        description: True when a reference portrait was supplied at creation (always
+          true here).
+        type: boolean
+      face_session_id:
+        description: Identifier used in every subsequent face verification call.
+        type: string
+      face_session_token:
+        description: Base64url-encoded blob the wallet uses to learn the session id
+          and stream URL.
+        type: string
+      websocket_url:
+        description: WebSocket endpoint the client streams camera frames to.
+        type: string
+    type: object
   main.HealthResponse:
     properties:
       ok:
@@ -39,6 +56,12 @@ definitions:
         description: True if passive authentication (signature verification) succeeded
         example: true
         type: boolean
+      face_session:
+        allOf:
+        - $ref: '#/definitions/main.FaceSession'
+        description: |-
+          Optional face verification session, present only when the face verification
+          integration is configured and a session was created from the DG2 portrait.
       is_expired:
         description: True if the document has expired
         example: false

--- a/backend/face_callback.go
+++ b/backend/face_callback.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"go-passport-issuer/models"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+// Face verification result statuses.
+const (
+	faceStatusPending = "pending"
+	faceStatusSuccess = "success"
+)
+
+// faceRecordPrefix namespaces the face verification records inside the shared
+// TokenStorage, keeping them separate from validation-session nonces.
+const faceRecordPrefix = "facerec:"
+
+// faceGateBodyRequired and friends are returned verbatim to the client so it can
+// branch on the reason a gated issuance was refused.
+const (
+	faceGateRequired = "face:required"
+	faceGateFailed   = "face:failed"
+	faceGateMismatch = "face:mismatch"
+	faceGatePending  = "face:pending"
+)
+
+// FaceRecord is the issuer-side state for one face verification session. It is
+// created (status "pending") when verify-passport starts the session and updated
+// to the terminal verdict by the signed callback (or the status poll). The
+// binding_secret authenticates the callback and is never returned to the wallet.
+type FaceRecord struct {
+	FaceSessionID   string   `json:"face_session_id"`
+	SessionID       string   `json:"session_id"`
+	BindingSecret   string   `json:"binding_secret"`
+	Dg2Sha256       string   `json:"dg2_sha256"`
+	Status          string   `json:"status"`
+	MatchConfidence *float64 `json:"match_confidence,omitempty"`
+	LivenessPassed  *bool    `json:"liveness_passed,omitempty"`
+}
+
+func faceRecordKey(faceSessionID string) string {
+	return faceRecordPrefix + faceSessionID
+}
+
+func storeFaceRecord(storage TokenStorage, rec *FaceRecord) error {
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("failed to marshal face record: %w", err)
+	}
+	return storage.StoreToken(faceRecordKey(rec.FaceSessionID), string(b))
+}
+
+func retrieveFaceRecord(storage TokenStorage, faceSessionID string) (*FaceRecord, error) {
+	raw, err := storage.RetrieveToken(faceRecordKey(faceSessionID))
+	if err != nil {
+		return nil, err
+	}
+	var rec FaceRecord
+	if err := json.Unmarshal([]byte(raw), &rec); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal face record: %w", err)
+	}
+	return &rec, nil
+}
+
+// portraitDataGroups lists the data-group keys that carry a face portrait, in
+// priority order: DG2 for eMRTD passports/ID cards, DG6 for ISO-18013 eDLs.
+var portraitDataGroups = []string{"DG2", "DG6"}
+
+// portraitRawBytes returns the raw bytes of the document's face portrait data
+// group (DG2 for passports/ID cards, DG6 for driving licences), if present.
+func portraitRawBytes(dataGroups map[string]string) ([]byte, bool) {
+	for _, key := range portraitDataGroups {
+		h := dataGroups[key]
+		if h == "" {
+			continue
+		}
+		raw, err := hex.DecodeString(h)
+		if err != nil {
+			continue
+		}
+		return raw, true
+	}
+	return nil, false
+}
+
+// portraitSha256Hex returns SHA256 of the raw portrait bytes (hex-encoded),
+// matching the face service's reference-photo salt: the issuer sends
+// base64(raw portrait DG) as the portrait, and the service hashes the decoded
+// bytes for binding. Returns "" when the document carries no portrait DG.
+func portraitSha256Hex(dataGroups map[string]string) string {
+	raw, ok := portraitRawBytes(dataGroups)
+	if !ok {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// canonicalJSON reproduces Python's
+// json.dumps(obj, sort_keys=True, separators=(",", ":")) byte-for-byte for the
+// callback payload: Go marshals maps with sorted keys and compact separators;
+// HTML escaping is disabled and the trailing newline trimmed. Numbers are
+// preserved verbatim via json.Number so integral floats (e.g. 1.0) are not
+// rewritten as 1.
+func canonicalJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// FaceCallbackResponse is returned to the face verification service.
+type FaceCallbackResponse struct {
+	Ok bool `json:"ok"`
+}
+
+// handleFaceCallback receives the signed verification result from the face
+// verification service. The payload signature is an HMAC-SHA256 (hex) of the
+// canonical JSON of the body without its "signature" field, keyed by the
+// session's binding_secret.
+//
+// @Summary Face verification result callback
+// @Description Server-to-server webhook called by the face verification service with the signed result of a session.
+// @Tags Face
+// @Accept json
+// @Produce json
+// @Success 200 {object} FaceCallbackResponse
+// @Failure 400 {string} string "invalid request"
+// @Failure 401 {string} string "invalid signature"
+// @Failure 404 {string} string "unknown session"
+// @Router /face/callback [post]
+func handleFaceCallback(state *ServerState, w http.ResponseWriter, r *http.Request) {
+	defer closeRequestBody(r)
+
+	if !requirePOST(w, r) {
+		return
+	}
+
+	const endpoint = "face/callback"
+
+	body, err := readLimitedBody(r)
+	if err != nil {
+		respondWithErr(w, http.StatusBadRequest, "invalid request", "failed to read callback body", err, "endpoint", endpoint)
+		return
+	}
+
+	// Decode preserving number literals so the signature recomputation matches
+	// the sender's canonical JSON exactly.
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	var payload map[string]any
+	if err := dec.Decode(&payload); err != nil {
+		respondWithErr(w, http.StatusBadRequest, "invalid request", "failed to decode callback body", err, "endpoint", endpoint)
+		return
+	}
+
+	faceSessionID, _ := payload["face_session_id"].(string)
+	if faceSessionID == "" {
+		respondWithErr(w, http.StatusBadRequest, "invalid request", "callback missing face_session_id", fmt.Errorf("missing face_session_id"), "endpoint", endpoint)
+		return
+	}
+
+	rec, err := retrieveFaceRecord(state.tokenStorage, faceSessionID)
+	if err != nil {
+		respondWithErr(w, http.StatusNotFound, "unknown session", "callback for unknown face session", err,
+			"endpoint", endpoint, "face_session_id", faceSessionID)
+		return
+	}
+
+	if !verifyCallbackSignature(payload, rec.BindingSecret) {
+		respondWithErr(w, http.StatusUnauthorized, "invalid signature", "callback signature mismatch", fmt.Errorf("hmac mismatch"),
+			"endpoint", endpoint, "face_session_id", faceSessionID)
+		return
+	}
+
+	// Signature verified — record the verdict.
+	result, _ := payload["result"].(string)
+	rec.Status = result
+	if details, ok := payload["details"].(map[string]any); ok {
+		rec.MatchConfidence = jsonNumberPtr(details["match_confidence"])
+		rec.LivenessPassed = boolPtr(details["liveness_passed"])
+	}
+	if err := storeFaceRecord(state.tokenStorage, rec); err != nil {
+		respondWithErr(w, http.StatusInternalServerError, ErrorInternal, "failed to persist face result", err,
+			"endpoint", endpoint, "face_session_id", faceSessionID)
+		return
+	}
+
+	slog.Info("recorded face verification result",
+		"face_session_id", faceSessionID, "result", result)
+
+	if err := writeJSON(w, http.StatusOK, FaceCallbackResponse{Ok: true}); err != nil {
+		respondWithErr(w, http.StatusInternalServerError, ErrorInternal, ERR_MARSHAL, err)
+	}
+}
+
+// verifyCallbackSignature recomputes HMAC-SHA256(binding_secret, canonical(body
+// without signature)) and compares it (constant time) against the hex signature
+// carried in the body.
+func verifyCallbackSignature(payload map[string]any, bindingSecret string) bool {
+	received, ok := payload["signature"].(string)
+	if !ok || received == "" || bindingSecret == "" {
+		return false
+	}
+
+	// Compare against a copy without the signature field.
+	unsigned := make(map[string]any, len(payload))
+	for k, v := range payload {
+		if k == "signature" {
+			continue
+		}
+		unsigned[k] = v
+	}
+
+	canonical, err := canonicalJSON(unsigned)
+	if err != nil {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, []byte(bindingSecret))
+	mac.Write(canonical)
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(expected), []byte(received))
+}
+
+// faceGateError carries the HTTP status and verbatim response body for a refused
+// gated issuance.
+type faceGateError struct {
+	code int
+	body string
+}
+
+func (e *faceGateError) Error() string { return e.body }
+
+// checkFaceGate enforces that face verification succeeded before issuance.
+// Returns nil when face verification is not required (disabled or configured
+// off) or when the gate passes. Never deletes the session, so the wallet can
+// retry once the verdict lands.
+func (state *ServerState) checkFaceGate(ctx context.Context, request models.ValidationRequest) *faceGateError {
+	if !state.requireFaceForIssuance {
+		return nil
+	}
+
+	if request.FaceSessionId == "" {
+		return &faceGateError{http.StatusForbidden, faceGateRequired}
+	}
+
+	rec, err := retrieveFaceRecord(state.tokenStorage, request.FaceSessionId)
+	if err != nil {
+		slog.Warn("issuance gate: no face record", "face_session_id", request.FaceSessionId, "error", err)
+		return &faceGateError{http.StatusForbidden, faceGateRequired}
+	}
+
+	// Bind the verdict to the document being issued: the face session must have
+	// been created from this document's portrait (DG2 for passports/ID cards,
+	// DG6 for driving licences).
+	wantHash := portraitSha256Hex(request.DataGroups)
+	if wantHash == "" || wantHash != rec.Dg2Sha256 {
+		slog.Warn("issuance gate: portrait hash mismatch", "face_session_id", request.FaceSessionId)
+		return &faceGateError{http.StatusForbidden, faceGateMismatch}
+	}
+
+	status := rec.Status
+
+	// Pull fallback: if the pushed callback has not arrived yet, poll the face
+	// service for the authoritative result.
+	if (status == "" || status == faceStatusPending) && state.faceStatusGetter != nil {
+		if res, perr := state.faceStatusGetter.GetSessionStatus(ctx, request.FaceSessionId); perr == nil && res != nil {
+			status = res.Status
+			rec.Status = res.Status
+			rec.MatchConfidence = res.MatchConfidence
+			rec.LivenessPassed = res.LivenessPassed
+			if status != "" && status != faceStatusPending {
+				if serr := storeFaceRecord(state.tokenStorage, rec); serr != nil {
+					slog.Warn("issuance gate: failed to persist polled face result", "error", serr)
+				}
+			}
+		} else if perr != nil {
+			slog.Warn("issuance gate: face status poll failed", "face_session_id", request.FaceSessionId, "error", perr)
+		}
+	}
+
+	switch status {
+	case faceStatusSuccess:
+		return nil
+	case "", faceStatusPending:
+		return &faceGateError{http.StatusPreconditionRequired, faceGatePending}
+	default:
+		return &faceGateError{http.StatusForbidden, faceGateFailed}
+	}
+}
+
+// readLimitedBody reads up to 1 MiB of the request body.
+func readLimitedBody(r *http.Request) ([]byte, error) {
+	return io.ReadAll(io.LimitReader(r.Body, 1<<20))
+}
+
+func jsonNumberPtr(v any) *float64 {
+	n, ok := v.(json.Number)
+	if !ok {
+		return nil
+	}
+	f, err := n.Float64()
+	if err != nil {
+		return nil
+	}
+	return &f
+}
+
+func boolPtr(v any) *bool {
+	b, ok := v.(bool)
+	if !ok {
+		return nil
+	}
+	return &b
+}

--- a/backend/face_callback_test.go
+++ b/backend/face_callback_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// pythonCanonicalSign mirrors the face verification service's signing exactly:
+// HMAC-SHA256(binding_secret, json.dumps(payload, sort_keys=True,
+// separators=(",", ":"))), hex-encoded. The canonical string is typed out here
+// (sorted keys, compact) so the test is independent of the production
+// canonicalJSON implementation.
+func pythonCanonicalSign(secret, canonical string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(canonical))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+const (
+	testFaceSessionID = "fs_test"
+	testBindingSecret = "super-secret-binding"
+	// DG2 raw bytes -> hex, and their SHA256 (matches the face service salt).
+	testDG2Hex = "deadbeef0102"
+)
+
+func testDG2Sha256() string {
+	raw, _ := hex.DecodeString(testDG2Hex)
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// fakeStatusGetter is the pull-fallback double.
+type fakeStatusGetter struct {
+	res    *FaceVerificationResult
+	err    error
+	called bool
+}
+
+func (f *fakeStatusGetter) GetSessionStatus(_ context.Context, _ string) (*FaceVerificationResult, error) {
+	f.called = true
+	return f.res, f.err
+}
+
+func seedFaceRecord(t *testing.T, storage TokenStorage, status string) {
+	t.Helper()
+	require.NoError(t, storeFaceRecord(storage, &FaceRecord{
+		FaceSessionID: testFaceSessionID,
+		SessionID:     "any",
+		BindingSecret: testBindingSecret,
+		Dg2Sha256:     testDG2Sha256(),
+		Status:        status,
+	}))
+}
+
+// --- Callback signature -----------------------------------------------------
+
+func TestFaceCallbackValidSignatureRecordsResult(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage)
+	seedFaceRecord(t, storage, faceStatusPending)
+
+	// Canonical form: top-level keys sorted (details, face_session_id, result,
+	// timestamp); details keys sorted.
+	canonical := `{"details":{"frames_processed":42,"liveness_passed":true,"liveness_score":0.9,"match_confidence":0.97,"verification_duration_ms":1234},"face_session_id":"fs_test","result":"success","timestamp":"2026-06-19T12:00:00+00:00"}`
+	sig := pythonCanonicalSign(testBindingSecret, canonical)
+
+	// Wire body: arbitrary key order + the signature field. The handler sorts.
+	body := `{"face_session_id":"fs_test","result":"success","timestamp":"2026-06-19T12:00:00+00:00","details":{"match_confidence":0.97,"liveness_passed":true,"liveness_score":0.9,"frames_processed":42,"verification_duration_ms":1234},"signature":"` + sig + `"}`
+
+	resp, err := http.Post("http://localhost:8081/api/face/callback", "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	rec, err := retrieveFaceRecord(storage, testFaceSessionID)
+	require.NoError(t, err)
+	require.Equal(t, faceStatusSuccess, rec.Status)
+	require.NotNil(t, rec.MatchConfidence)
+	require.InDelta(t, 0.97, *rec.MatchConfidence, 1e-9)
+	require.NotNil(t, rec.LivenessPassed)
+	require.True(t, *rec.LivenessPassed)
+}
+
+func TestFaceCallbackBadSignatureRejected(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage)
+	seedFaceRecord(t, storage, faceStatusPending)
+
+	body := `{"face_session_id":"fs_test","result":"success","timestamp":"t","details":{},"signature":"deadbeef"}`
+	resp, err := http.Post("http://localhost:8081/api/face/callback", "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// Status must be unchanged.
+	rec, err := retrieveFaceRecord(storage, testFaceSessionID)
+	require.NoError(t, err)
+	require.Equal(t, faceStatusPending, rec.Status)
+}
+
+func TestFaceCallbackUnknownSession(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage)
+
+	body := `{"face_session_id":"fs_missing","result":"success","timestamp":"t","details":{},"signature":"x"}`
+	resp, err := http.Post("http://localhost:8081/api/face/callback", "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	_ = resp.Body.Close()
+}
+
+// --- Issuance gate ----------------------------------------------------------
+
+func issueReq(session, nonce string) any {
+	r := newReq(session, nonce, withDG("DG2", testDG2Hex))
+	r.FaceSessionId = testFaceSessionID
+	return r
+}
+
+func TestIssueGatedSuccess(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage, func(s *ServerState) { s.requireFaceForIssuance = true })
+	seedFaceRecord(t, storage, faceStatusSuccess)
+
+	session, nonce := startValidation(t)
+	resp, body, decoded := postJSON[IssuanceResponse](t, "http://localhost:8081/api/issue-passport", issueReq(session, nonce))
+	mustStatus(t, resp, http.StatusOK, body)
+	require.Equal(t, "test-jwt", decoded.Jwt)
+}
+
+func TestIssueGatedFailedVerdict(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage, func(s *ServerState) { s.requireFaceForIssuance = true })
+	seedFaceRecord(t, storage, "failed")
+
+	session, nonce := startValidation(t)
+	resp, body, _ := postJSON[IssuanceResponse](t, "http://localhost:8081/api/issue-passport", issueReq(session, nonce))
+	mustStatus(t, resp, http.StatusForbidden, body)
+	require.Contains(t, string(body), faceGateFailed)
+}
+
+func TestIssueGatedMissingFaceSessionID(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage, func(s *ServerState) { s.requireFaceForIssuance = true })
+
+	session, nonce := startValidation(t)
+	req := newReq(session, nonce, withDG("DG2", testDG2Hex)) // no FaceSessionId
+	resp, body, _ := postJSON[IssuanceResponse](t, "http://localhost:8081/api/issue-passport", req)
+	mustStatus(t, resp, http.StatusForbidden, body)
+	require.Contains(t, string(body), faceGateRequired)
+}
+
+func TestIssueGatedDG2Mismatch(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage, func(s *ServerState) { s.requireFaceForIssuance = true })
+	seedFaceRecord(t, storage, faceStatusSuccess)
+
+	session, nonce := startValidation(t)
+	req := newReq(session, nonce, withDG("DG2", "00ff")) // different DG2 -> different hash
+	req.FaceSessionId = testFaceSessionID
+	resp, body, _ := postJSON[IssuanceResponse](t, "http://localhost:8081/api/issue-passport", req)
+	mustStatus(t, resp, http.StatusForbidden, body)
+	require.Contains(t, string(body), faceGateMismatch)
+}
+
+func TestIssueGatedPendingNoGetter(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage, func(s *ServerState) { s.requireFaceForIssuance = true })
+	seedFaceRecord(t, storage, faceStatusPending)
+
+	session, nonce := startValidation(t)
+	resp, body, _ := postJSON[IssuanceResponse](t, "http://localhost:8081/api/issue-passport", issueReq(session, nonce))
+	mustStatus(t, resp, http.StatusPreconditionRequired, body)
+	require.Contains(t, string(body), faceGatePending)
+}
+
+func TestIssueGatedPendingPollFallbackSucceeds(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	getter := &fakeStatusGetter{res: &FaceVerificationResult{Status: faceStatusSuccess}}
+	startTestServer(t, storage, func(s *ServerState) {
+		s.requireFaceForIssuance = true
+		s.faceStatusGetter = getter
+	})
+	seedFaceRecord(t, storage, faceStatusPending)
+
+	session, nonce := startValidation(t)
+	resp, body, decoded := postJSON[IssuanceResponse](t, "http://localhost:8081/api/issue-passport", issueReq(session, nonce))
+	mustStatus(t, resp, http.StatusOK, body)
+	require.True(t, getter.called)
+	require.Equal(t, "test-jwt", decoded.Jwt)
+}
+
+// Driving licences bind on the DG6 portrait (not DG2). The same gate applies to
+// issue-driving-licence. Reuses the test portrait bytes under the DG6 key, so
+// the seeded record's hash matches.
+func TestIssueDrivingLicenceGatedSuccess(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage, func(s *ServerState) { s.requireFaceForIssuance = true })
+	seedFaceRecord(t, storage, faceStatusSuccess)
+
+	session, nonce := startValidation(t)
+	r := newReq(session, nonce, withDG("DG6", testDG2Hex))
+	r.FaceSessionId = testFaceSessionID
+	resp, body, decoded := postJSON[IssuanceResponse](t, "http://localhost:8081/api/issue-driving-licence", r)
+	mustStatus(t, resp, http.StatusOK, body)
+	require.Equal(t, "test-jwt", decoded.Jwt)
+}
+
+func TestIssueDrivingLicenceGatedFailedVerdict(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage, func(s *ServerState) { s.requireFaceForIssuance = true })
+	seedFaceRecord(t, storage, "failed")
+
+	session, nonce := startValidation(t)
+	r := newReq(session, nonce, withDG("DG6", testDG2Hex))
+	r.FaceSessionId = testFaceSessionID
+	resp, body, _ := postJSON[IssuanceResponse](t, "http://localhost:8081/api/issue-driving-licence", r)
+	mustStatus(t, resp, http.StatusForbidden, body)
+	require.Contains(t, string(body), faceGateFailed)
+}
+
+// Backwards compatibility: with face verification not required, issuance works
+// exactly as before — no face_session_id needed.
+func TestIssueUngatedWhenFaceNotRequired(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage) // requireFaceForIssuance defaults to false
+
+	session, nonce := startValidation(t)
+	req := newReq(session, nonce)
+	resp, body, decoded := postJSON[IssuanceResponse](t, "http://localhost:8081/api/issue-passport", req)
+	mustStatus(t, resp, http.StatusOK, body)
+	require.Equal(t, "test-jwt", decoded.Jwt)
+}

--- a/backend/face_verification.go
+++ b/backend/face_verification.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -37,7 +38,29 @@ type FaceSessionCreator interface {
 	// (base64-encoded), since the binding key is derived from
 	// SHA256(reference_photo) and the mobile app derives the same key over the
 	// raw DG2 it read from the chip.
-	CreateSession(ctx context.Context, portraitImage string) (*FaceSession, error)
+	//
+	// It returns the public session (safe to hand to the wallet) and the
+	// binding_secret. The binding_secret authenticates the result callback and
+	// must be persisted server-side; it is never returned to the wallet.
+	CreateSession(ctx context.Context, portraitImage string) (session *FaceSession, bindingSecret string, err error)
+}
+
+// FaceVerificationResult is the authoritative outcome of a face verification
+// session, as learned from the signed callback or the status endpoint.
+type FaceVerificationResult struct {
+	// "success", "failed", "error", or "pending" when not yet complete.
+	Status          string   `json:"status"`
+	MatchConfidence *float64 `json:"match_confidence,omitempty"`
+	LivenessPassed  *bool    `json:"liveness_passed,omitempty"`
+}
+
+// FaceSessionStatusGetter polls the face verification service for the result of
+// a session. It is the pull fallback used when the pushed callback has not yet
+// arrived by the time issuance is requested.
+type FaceSessionStatusGetter interface {
+	// GetSessionStatus returns the current result for a face session. Status is
+	// "pending" while the session is not yet complete.
+	GetSessionStatus(ctx context.Context, faceSessionID string) (*FaceVerificationResult, error)
 }
 
 // faceSessionRequest is the body for POST /api/face/session.
@@ -69,6 +92,10 @@ type FaceVerificationConfig struct {
 	CallbackURL string `json:"callback_url,omitempty"`
 	// Optional request timeout in seconds (defaults to 10s).
 	TimeoutSeconds int `json:"timeout_seconds,omitempty"`
+	// Whether issuance must be gated on a successful face verification. When nil
+	// it defaults to true (gate on) for any configured (URL set) integration;
+	// set false to run face verification as advisory only.
+	RequireFaceForIssuance *bool `json:"require_face_for_issuance,omitempty"`
 }
 
 // FaceVerificationClient talks to the face verification service over HTTP.
@@ -105,9 +132,9 @@ func NewFaceVerificationClient(config FaceVerificationConfig) *FaceVerificationC
 }
 
 // CreateSession implements FaceSessionCreator.
-func (c *FaceVerificationClient) CreateSession(ctx context.Context, portraitImage string) (*FaceSession, error) {
+func (c *FaceVerificationClient) CreateSession(ctx context.Context, portraitImage string) (*FaceSession, string, error) {
 	if portraitImage == "" {
-		return nil, fmt.Errorf("portrait image is empty")
+		return nil, "", fmt.Errorf("portrait image is empty")
 	}
 
 	body, err := json.Marshal(faceSessionRequest{
@@ -116,19 +143,19 @@ func (c *FaceVerificationClient) CreateSession(ctx context.Context, portraitImag
 		PortraitImage: portraitImage,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal face session request: %w", err)
+		return nil, "", fmt.Errorf("failed to marshal face session request: %w", err)
 	}
 
 	endpoint := c.baseURL + "/api/face/session"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("failed to build face session request: %w", err)
+		return nil, "", fmt.Errorf("failed to build face session request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to call face verification service: %w", err)
+		return nil, "", fmt.Errorf("failed to call face verification service: %w", err)
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
@@ -138,19 +165,19 @@ func (c *FaceVerificationClient) CreateSession(ctx context.Context, portraitImag
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read face session response: %w", err)
+		return nil, "", fmt.Errorf("failed to read face session response: %w", err)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("face verification service returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, "", fmt.Errorf("face verification service returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	var parsed faceSessionResponse
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
-		return nil, fmt.Errorf("failed to decode face session response: %w", err)
+		return nil, "", fmt.Errorf("failed to decode face session response: %w", err)
 	}
 	if parsed.FaceSessionID == "" {
-		return nil, fmt.Errorf("face verification service returned empty session id")
+		return nil, "", fmt.Errorf("face verification service returned empty session id")
 	}
 
 	return &FaceSession{
@@ -158,5 +185,58 @@ func (c *FaceVerificationClient) CreateSession(ctx context.Context, portraitImag
 		FaceSessionToken: parsed.FaceSessionToken,
 		WebsocketURL:     parsed.WebsocketURL,
 		BindingKeyReady:  parsed.BindingKeyReady,
-	}, nil
+	}, parsed.BindingSecret, nil
+}
+
+// sessionStatusResponse is the subset of GET /api/face/session/{id}/status we
+// need. The face service nests the terminal verdict under "result".
+type sessionStatusResponse struct {
+	Status string `json:"status"` // created|connected|verifying|completed|failed|expired
+	Result *struct {
+		Result          string   `json:"result"` // success|failed|...
+		MatchConfidence *float64 `json:"match_confidence"`
+		LivenessPassed  *bool    `json:"liveness_passed"`
+	} `json:"result"`
+}
+
+// GetSessionStatus implements FaceSessionStatusGetter.
+func (c *FaceVerificationClient) GetSessionStatus(ctx context.Context, faceSessionID string) (*FaceVerificationResult, error) {
+	endpoint := fmt.Sprintf("%s/api/face/session/%s/status", c.baseURL, url.PathEscape(faceSessionID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build face status request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call face verification status: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			slog.Error("failed to close face status response body", "error", cerr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read face status response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("face verification status returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed sessionStatusResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to decode face status response: %w", err)
+	}
+
+	// Prefer the explicit terminal verdict; fall back to a pending state.
+	if parsed.Result != nil && parsed.Result.Result != "" {
+		return &FaceVerificationResult{
+			Status:          parsed.Result.Result,
+			MatchConfidence: parsed.Result.MatchConfidence,
+			LivenessPassed:  parsed.Result.LivenessPassed,
+		}, nil
+	}
+	return &FaceVerificationResult{Status: faceStatusPending}, nil
 }

--- a/backend/face_verification.go
+++ b/backend/face_verification.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// FaceSession is the subset of a face verification session that is safe to
+// return to the caller (e.g. the wallet). It lets the client connect to the
+// live verification stream. The binding_secret returned by the face service is
+// deliberately NOT exposed here: it is used to authenticate result callbacks and
+// must not leave the issuer.
+type FaceSession struct {
+	// Identifier used in every subsequent face verification call.
+	FaceSessionID string `json:"face_session_id"`
+	// Base64url-encoded blob the wallet uses to learn the session id and stream URL.
+	FaceSessionToken string `json:"face_session_token,omitempty"`
+	// WebSocket endpoint the client streams camera frames to.
+	WebsocketURL string `json:"websocket_url,omitempty"`
+	// True when a reference portrait was supplied at creation (always true here).
+	BindingKeyReady bool `json:"binding_key_ready"`
+}
+
+// FaceSessionCreator starts a face verification session bound to a reference
+// portrait. It is an interface so the HTTP client can be swapped for a fake in
+// tests.
+type FaceSessionCreator interface {
+	// CreateSession starts a session at the face verification service, passing
+	// the DG2 portrait (base64-encoded image) as the reference photo.
+	CreateSession(ctx context.Context, portraitImage string) (*FaceSession, error)
+}
+
+// faceSessionRequest is the body for POST /api/face/session.
+type faceSessionRequest struct {
+	VerifierID    string `json:"verifier_id"`
+	CallbackURL   string `json:"callback_url,omitempty"`
+	PortraitImage string `json:"portrait_image"`
+}
+
+// faceSessionResponse is the full response from POST /api/face/session. The
+// binding_secret is read but never propagated outside the issuer.
+type faceSessionResponse struct {
+	FaceSessionID    string `json:"face_session_id"`
+	FaceSessionToken string `json:"face_session_token"`
+	BindingSecret    string `json:"binding_secret"`
+	WebsocketURL     string `json:"websocket_url"`
+	BindingKeyReady  bool   `json:"binding_key_ready"`
+}
+
+// FaceVerificationConfig configures the optional integration with the
+// face verification service. When URL is empty the integration is disabled and
+// validation behaves exactly as before.
+type FaceVerificationConfig struct {
+	// Base URL of the face verification service, e.g. https://face.example.com.
+	URL string `json:"url"`
+	// Identifier of this issuer as known to the face verification service.
+	VerifierID string `json:"verifier_id"`
+	// Optional URL the face service calls with the signed result.
+	CallbackURL string `json:"callback_url,omitempty"`
+	// Optional request timeout in seconds (defaults to 10s).
+	TimeoutSeconds int `json:"timeout_seconds,omitempty"`
+}
+
+// FaceVerificationClient talks to the face verification service over HTTP.
+type FaceVerificationClient struct {
+	baseURL     string
+	verifierID  string
+	callbackURL string
+	httpClient  *http.Client
+}
+
+// NewFaceVerificationClient builds a client from config, or returns nil (with no
+// error) when the integration is not configured.
+func NewFaceVerificationClient(config FaceVerificationConfig) *FaceVerificationClient {
+	if strings.TrimSpace(config.URL) == "" {
+		return nil
+	}
+
+	timeout := 10 * time.Second
+	if config.TimeoutSeconds > 0 {
+		timeout = time.Duration(config.TimeoutSeconds) * time.Second
+	}
+
+	verifierID := config.VerifierID
+	if verifierID == "" {
+		verifierID = "passport-issuer"
+	}
+
+	return &FaceVerificationClient{
+		baseURL:     strings.TrimRight(config.URL, "/"),
+		verifierID:  verifierID,
+		callbackURL: config.CallbackURL,
+		httpClient:  &http.Client{Timeout: timeout},
+	}
+}
+
+// CreateSession implements FaceSessionCreator.
+func (c *FaceVerificationClient) CreateSession(ctx context.Context, portraitImage string) (*FaceSession, error) {
+	if portraitImage == "" {
+		return nil, fmt.Errorf("portrait image is empty")
+	}
+
+	body, err := json.Marshal(faceSessionRequest{
+		VerifierID:    c.verifierID,
+		CallbackURL:   c.callbackURL,
+		PortraitImage: portraitImage,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal face session request: %w", err)
+	}
+
+	endpoint := c.baseURL + "/api/face/session"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build face session request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call face verification service: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			slog.Error("failed to close face session response body", "error", cerr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read face session response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("face verification service returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed faceSessionResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to decode face session response: %w", err)
+	}
+	if parsed.FaceSessionID == "" {
+		return nil, fmt.Errorf("face verification service returned empty session id")
+	}
+
+	return &FaceSession{
+		FaceSessionID:    parsed.FaceSessionID,
+		FaceSessionToken: parsed.FaceSessionToken,
+		WebsocketURL:     parsed.WebsocketURL,
+		BindingKeyReady:  parsed.BindingKeyReady,
+	}, nil
+}

--- a/backend/face_verification.go
+++ b/backend/face_verification.go
@@ -33,7 +33,10 @@ type FaceSession struct {
 // tests.
 type FaceSessionCreator interface {
 	// CreateSession starts a session at the face verification service, passing
-	// the DG2 portrait (base64-encoded image) as the reference photo.
+	// the reference photo as portraitImage. This must be the original DG2 bytes
+	// (base64-encoded), since the binding key is derived from
+	// SHA256(reference_photo) and the mobile app derives the same key over the
+	// raw DG2 it read from the chip.
 	CreateSession(ctx context.Context, portraitImage string) (*FaceSession, error)
 }
 

--- a/backend/face_verification_test.go
+++ b/backend/face_verification_test.go
@@ -2,15 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
-	"go-passport-issuer/document/edl"
-	"go-passport-issuer/models"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gmrtd/gmrtd/document"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,16 +26,6 @@ func (f *fakeFaceSessionCreator) CreateSession(_ context.Context, portrait strin
 	f.called = true
 	f.gotPortrait = portrait
 	return f.session, f.err
-}
-
-// photoConverter is a fake DocumentDataConverter returning a fixed DG2 portrait.
-type photoConverter struct{ photo string }
-
-func (c photoConverter) ToPassportData(_ document.Document, _ bool) (models.PassportData, error) {
-	return models.PassportData{DocumentNumber: "X", Photo: c.photo}, nil
-}
-func (photoConverter) ToDrivingLicenceData(_ edl.DrivingLicenceDocument, _ bool) (models.EDLData, error) {
-	return models.EDLData{DocumentNumber: "123"}, nil
 }
 
 func TestNewFaceVerificationClientDisabledWhenNoURL(t *testing.T) {
@@ -114,17 +103,24 @@ func TestVerifyPassportReturnsFaceSession(t *testing.T) {
 	}}
 	startTestServer(t, storage, func(s *ServerState) {
 		s.faceSessionCreator = creator
-		s.converter = photoConverter{photo: "dg2-portrait-base64"}
 	})
 
 	session, nonce := startValidation(t)
-	req := newReq(session, nonce)
+	// DG2 is sent as hex; the face session must be bound to the ORIGINAL DG2
+	// bytes (base64), not a re-encoded portrait, so the mobile app derives the
+	// same binding key over the raw DG2 it read from the chip.
+	dg2Hex := "deadbeef0102"
+	req := newReq(session, nonce, withDG("DG2", dg2Hex))
 
 	resp, body, decoded := postJSON[VerificationResponse](t, "http://localhost:8081/api/verify-passport", req)
 	mustStatus(t, resp, http.StatusOK, body)
 
+	rawDG2, err := hex.DecodeString(dg2Hex)
+	require.NoError(t, err)
+	wantPortrait := base64.StdEncoding.EncodeToString(rawDG2)
+
 	require.True(t, creator.called)
-	require.Equal(t, "dg2-portrait-base64", creator.gotPortrait)
+	require.Equal(t, wantPortrait, creator.gotPortrait)
 	require.NotNil(t, decoded.FaceSession)
 	require.Equal(t, "fs_xyz", decoded.FaceSession.FaceSessionID)
 	// Binding secret must never appear in the response body.
@@ -152,11 +148,10 @@ func TestVerifyPassportFaceSessionFailureIsNonFatal(t *testing.T) {
 	creator := &fakeFaceSessionCreator{err: io.ErrUnexpectedEOF}
 	startTestServer(t, storage, func(s *ServerState) {
 		s.faceSessionCreator = creator
-		s.converter = photoConverter{photo: "dg2-portrait-base64"}
 	})
 
 	session, nonce := startValidation(t)
-	req := newReq(session, nonce)
+	req := newReq(session, nonce, withDG("DG2", "deadbeef"))
 
 	resp, body, decoded := postJSON[VerificationResponse](t, "http://localhost:8081/api/verify-passport", req)
 	mustStatus(t, resp, http.StatusOK, body)

--- a/backend/face_verification_test.go
+++ b/backend/face_verification_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"go-passport-issuer/document/edl"
+	"go-passport-issuer/models"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gmrtd/gmrtd/document"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFaceSessionCreator records the portrait it received and returns a canned
+// session (or error).
+type fakeFaceSessionCreator struct {
+	gotPortrait string
+	called      bool
+	session     *FaceSession
+	err         error
+}
+
+func (f *fakeFaceSessionCreator) CreateSession(_ context.Context, portrait string) (*FaceSession, error) {
+	f.called = true
+	f.gotPortrait = portrait
+	return f.session, f.err
+}
+
+// photoConverter is a fake DocumentDataConverter returning a fixed DG2 portrait.
+type photoConverter struct{ photo string }
+
+func (c photoConverter) ToPassportData(_ document.Document, _ bool) (models.PassportData, error) {
+	return models.PassportData{DocumentNumber: "X", Photo: c.photo}, nil
+}
+func (photoConverter) ToDrivingLicenceData(_ edl.DrivingLicenceDocument, _ bool) (models.EDLData, error) {
+	return models.EDLData{DocumentNumber: "123"}, nil
+}
+
+func TestNewFaceVerificationClientDisabledWhenNoURL(t *testing.T) {
+	require.Nil(t, NewFaceVerificationClient(FaceVerificationConfig{}))
+	require.Nil(t, NewFaceVerificationClient(FaceVerificationConfig{URL: "   "}))
+	require.NotNil(t, NewFaceVerificationClient(FaceVerificationConfig{URL: "https://face.example"}))
+}
+
+func TestFaceClientCreateSessionSuccess(t *testing.T) {
+	var gotBody faceSessionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/face/session", r.URL.Path)
+		b, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(b, &gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(faceSessionResponse{
+			FaceSessionID:    "fs_abc123",
+			FaceSessionToken: "tok",
+			BindingSecret:    "secret-should-not-leak",
+			WebsocketURL:     "wss://face.example/stream/fs_abc123",
+			BindingKeyReady:  true,
+		})
+	}))
+	defer srv.Close()
+
+	client := NewFaceVerificationClient(FaceVerificationConfig{
+		URL:         srv.URL,
+		VerifierID:  "passport-issuer",
+		CallbackURL: "https://issuer.example/cb",
+	})
+	require.NotNil(t, client)
+
+	session, err := client.CreateSession(context.Background(), "base64-dg2-portrait")
+	require.NoError(t, err)
+	require.Equal(t, "fs_abc123", session.FaceSessionID)
+	require.Equal(t, "tok", session.FaceSessionToken)
+	require.Equal(t, "wss://face.example/stream/fs_abc123", session.WebsocketURL)
+	require.True(t, session.BindingKeyReady)
+
+	// Request carried the DG2 portrait and config values.
+	require.Equal(t, "base64-dg2-portrait", gotBody.PortraitImage)
+	require.Equal(t, "passport-issuer", gotBody.VerifierID)
+	require.Equal(t, "https://issuer.example/cb", gotBody.CallbackURL)
+}
+
+func TestFaceClientCreateSessionErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	client := NewFaceVerificationClient(FaceVerificationConfig{URL: srv.URL})
+	_, err := client.CreateSession(context.Background(), "portrait")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "500")
+}
+
+func TestFaceClientCreateSessionEmptyPortrait(t *testing.T) {
+	client := NewFaceVerificationClient(FaceVerificationConfig{URL: "https://face.example"})
+	_, err := client.CreateSession(context.Background(), "")
+	require.Error(t, err)
+}
+
+// Integration: verify-passport returns a face_session when the creator is set
+// and a DG2 portrait is available.
+func TestVerifyPassportReturnsFaceSession(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	creator := &fakeFaceSessionCreator{session: &FaceSession{
+		FaceSessionID:    "fs_xyz",
+		FaceSessionToken: "tok",
+		WebsocketURL:     "wss://face.example/stream/fs_xyz",
+		BindingKeyReady:  true,
+	}}
+	startTestServer(t, storage, func(s *ServerState) {
+		s.faceSessionCreator = creator
+		s.converter = photoConverter{photo: "dg2-portrait-base64"}
+	})
+
+	session, nonce := startValidation(t)
+	req := newReq(session, nonce)
+
+	resp, body, decoded := postJSON[VerificationResponse](t, "http://localhost:8081/api/verify-passport", req)
+	mustStatus(t, resp, http.StatusOK, body)
+
+	require.True(t, creator.called)
+	require.Equal(t, "dg2-portrait-base64", creator.gotPortrait)
+	require.NotNil(t, decoded.FaceSession)
+	require.Equal(t, "fs_xyz", decoded.FaceSession.FaceSessionID)
+	// Binding secret must never appear in the response body.
+	require.NotContains(t, string(body), "binding_secret")
+}
+
+// Backwards compatibility: with no creator configured the response has no
+// face_session field at all.
+func TestVerifyPassportNoFaceSessionWhenDisabled(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	startTestServer(t, storage)
+
+	session, nonce := startValidation(t)
+	req := newReq(session, nonce)
+
+	resp, body, decoded := postJSON[VerificationResponse](t, "http://localhost:8081/api/verify-passport", req)
+	mustStatus(t, resp, http.StatusOK, body)
+	require.Nil(t, decoded.FaceSession)
+	require.NotContains(t, string(body), "face_session")
+}
+
+// Non-fatal: a face service failure must not fail passport validation.
+func TestVerifyPassportFaceSessionFailureIsNonFatal(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	creator := &fakeFaceSessionCreator{err: io.ErrUnexpectedEOF}
+	startTestServer(t, storage, func(s *ServerState) {
+		s.faceSessionCreator = creator
+		s.converter = photoConverter{photo: "dg2-portrait-base64"}
+	})
+
+	session, nonce := startValidation(t)
+	req := newReq(session, nonce)
+
+	resp, body, decoded := postJSON[VerificationResponse](t, "http://localhost:8081/api/verify-passport", req)
+	mustStatus(t, resp, http.StatusOK, body)
+	require.True(t, creator.called)
+	require.Nil(t, decoded.FaceSession)
+}

--- a/backend/face_verification_test.go
+++ b/backend/face_verification_test.go
@@ -16,16 +16,17 @@ import (
 // fakeFaceSessionCreator records the portrait it received and returns a canned
 // session (or error).
 type fakeFaceSessionCreator struct {
-	gotPortrait string
-	called      bool
-	session     *FaceSession
-	err         error
+	gotPortrait   string
+	called        bool
+	session       *FaceSession
+	bindingSecret string
+	err           error
 }
 
-func (f *fakeFaceSessionCreator) CreateSession(_ context.Context, portrait string) (*FaceSession, error) {
+func (f *fakeFaceSessionCreator) CreateSession(_ context.Context, portrait string) (*FaceSession, string, error) {
 	f.called = true
 	f.gotPortrait = portrait
-	return f.session, f.err
+	return f.session, f.bindingSecret, f.err
 }
 
 func TestNewFaceVerificationClientDisabledWhenNoURL(t *testing.T) {
@@ -59,12 +60,14 @@ func TestFaceClientCreateSessionSuccess(t *testing.T) {
 	})
 	require.NotNil(t, client)
 
-	session, err := client.CreateSession(context.Background(), "base64-dg2-portrait")
+	session, bindingSecret, err := client.CreateSession(context.Background(), "base64-dg2-portrait")
 	require.NoError(t, err)
 	require.Equal(t, "fs_abc123", session.FaceSessionID)
 	require.Equal(t, "tok", session.FaceSessionToken)
 	require.Equal(t, "wss://face.example/stream/fs_abc123", session.WebsocketURL)
 	require.True(t, session.BindingKeyReady)
+	// binding_secret is captured server-side (never returned to the wallet).
+	require.Equal(t, "secret-should-not-leak", bindingSecret)
 
 	// Request carried the DG2 portrait and config values.
 	require.Equal(t, "base64-dg2-portrait", gotBody.PortraitImage)
@@ -80,14 +83,14 @@ func TestFaceClientCreateSessionErrorStatus(t *testing.T) {
 	defer srv.Close()
 
 	client := NewFaceVerificationClient(FaceVerificationConfig{URL: srv.URL})
-	_, err := client.CreateSession(context.Background(), "portrait")
+	_, _, err := client.CreateSession(context.Background(), "portrait")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "500")
 }
 
 func TestFaceClientCreateSessionEmptyPortrait(t *testing.T) {
 	client := NewFaceVerificationClient(FaceVerificationConfig{URL: "https://face.example"})
-	_, err := client.CreateSession(context.Background(), "")
+	_, _, err := client.CreateSession(context.Background(), "")
 	require.Error(t, err)
 }
 

--- a/backend/integration_test.go
+++ b/backend/integration_test.go
@@ -227,7 +227,10 @@ func TestPassportActiveAuthSkipNoSig(t *testing.T) {
 	require.False(t, skipped)
 }
 
-func TestPassportVerifySuccessRemovesSession(t *testing.T) {
+// New contract: verify-passport does NOT consume the session. The same session
+// (and its single chip-read AA signature) is reused by the gated issue-passport
+// call; the session is consumed by issuance or expires via TTL.
+func TestPassportVerifyKeepsSession(t *testing.T) {
 	storage := NewInMemoryTokenStorage()
 	startTestServer(t, storage)
 
@@ -238,8 +241,8 @@ func TestPassportVerifySuccessRemovesSession(t *testing.T) {
 	mustStatus(t, resp, http.StatusOK, body)
 
 	got, err := storage.RetrieveToken(session)
-	require.Error(t, err)
-	require.Equal(t, "", got)
+	require.NoError(t, err)
+	require.Equal(t, nonce, got)
 }
 
 func TestPassportVerifyFailBadNonce(t *testing.T) {
@@ -256,7 +259,9 @@ func TestPassportVerifyFailBadNonce(t *testing.T) {
 	mustStatus(t, resp, http.StatusBadRequest, body)
 }
 
-func TestPassportVerifyFailSessionReuse(t *testing.T) {
+// New contract: verify-passport is repeatable — it no longer consumes the
+// session, so a second verify on the same session still succeeds.
+func TestPassportVerifyAllowsSessionReuse(t *testing.T) {
 	storage := NewInMemoryTokenStorage()
 	startTestServer(t, storage)
 
@@ -267,5 +272,5 @@ func TestPassportVerifyFailSessionReuse(t *testing.T) {
 	mustStatus(t, resp1, http.StatusOK, body1)
 
 	resp2, body2, _ := postJSON[map[string]any](t, "http://localhost:8081/api/verify-passport", req)
-	mustStatus(t, resp2, http.StatusBadRequest, body2)
+	mustStatus(t, resp2, http.StatusOK, body2)
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -145,9 +145,17 @@ func main() {
 	// interface value nil (rather than a typed-nil client) to avoid the Go
 	// nil-interface gotcha at the call site.
 	var faceSessionCreator FaceSessionCreator
+	var faceStatusGetter FaceSessionStatusGetter
+	requireFaceForIssuance := false
 	if client := NewFaceVerificationClient(config.FaceVerification); client != nil {
 		faceSessionCreator = client
-		slog.Info("Face verification enabled", "url", config.FaceVerification.URL)
+		faceStatusGetter = client
+		// Gate issuance by default; only off when explicitly disabled.
+		requireFaceForIssuance = config.FaceVerification.RequireFaceForIssuance == nil ||
+			*config.FaceVerification.RequireFaceForIssuance
+		slog.Info("Face verification enabled",
+			"url", config.FaceVerification.URL,
+			"require_for_issuance", requireFaceForIssuance)
 	} else {
 		slog.Info("Face verification disabled (no url configured)")
 	}
@@ -162,6 +170,8 @@ func main() {
 		converter:              IssuanceRequestConverterImpl{},
 		drivingLicenceParser:   DrivingLicenceParserImpl{},
 		faceSessionCreator:     faceSessionCreator,
+		faceStatusGetter:       faceStatusGetter,
+		requireFaceForIssuance: requireFaceForIssuance,
 	}
 
 	server, err := NewServer(&serverState, config.ServerConfig)

--- a/backend/main.go
+++ b/backend/main.go
@@ -39,6 +39,7 @@ type Config struct {
 	RedisConfig             redis.RedisConfig         `json:"redis_config"`
 	RedisSentinelConfig     redis.RedisSentinelConfig `json:"redis_sentinel_config"`
 	LogLevel                string                    `json:"log_level"`
+	FaceVerification        FaceVerificationConfig    `json:"face_verification"`
 }
 
 type CredentialConfig struct {
@@ -139,6 +140,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Optional face verification integration. When no URL is configured the
+	// creator stays nil and validation behaves exactly as before. We keep the
+	// interface value nil (rather than a typed-nil client) to avoid the Go
+	// nil-interface gotcha at the call site.
+	var faceSessionCreator FaceSessionCreator
+	if client := NewFaceVerificationClient(config.FaceVerification); client != nil {
+		faceSessionCreator = client
+		slog.Info("Face verification enabled", "url", config.FaceVerification.URL)
+	} else {
+		slog.Info("Face verification disabled (no url configured)")
+	}
+
 	serverState := ServerState{
 		irmaServerURL:          config.IrmaServerUrl,
 		jwtCreators:            jwtCreators,
@@ -148,6 +161,7 @@ func main() {
 		documentValidator:      DocumentValidatorImpl{},
 		converter:              IssuanceRequestConverterImpl{},
 		drivingLicenceParser:   DrivingLicenceParserImpl{},
+		faceSessionCreator:     faceSessionCreator,
 	}
 
 	server, err := NewServer(&serverState, config.ServerConfig)

--- a/backend/models/passport_validation_request.go
+++ b/backend/models/passport_validation_request.go
@@ -12,4 +12,8 @@ type ValidationRequest struct {
 	EFSOD string `json:"ef_sod" example:"778201ab..."`
 	// Hex-encoded active authentication signature (optional)
 	ActiveAuthSignature string `json:"aa_signature,omitempty" example:"304502..."`
+	// Face verification session id obtained from /verify-passport (optional).
+	// Required on issuance only when face verification is enabled and required;
+	// it lets the issuer look up the authoritative face verification result.
+	FaceSessionId string `json:"face_session_id,omitempty" example:"fs_abc123"`
 }

--- a/backend/server.go
+++ b/backend/server.go
@@ -55,6 +55,8 @@ type ServerState struct {
 	documentValidator      DocumentValidator
 	drivingLicenceParser   DrivingLicenceParser
 	converter              DocumentDataConverter
+	// Optional; nil when face verification is not configured.
+	faceSessionCreator FaceSessionCreator
 }
 
 type SpaHandler struct {
@@ -178,6 +180,9 @@ type VerificationResponse struct {
 	AuthenticChip bool `json:"authentic_chip" example:"true"`
 	// True if the document has expired
 	IsExpired bool `json:"is_expired" example:"false"`
+	// Optional face verification session, present only when the face verification
+	// integration is configured and a session was created from the DG2 portrait.
+	FaceSession *FaceSession `json:"face_session,omitempty"`
 }
 
 // HealthResponse contains the health status of the service
@@ -343,6 +348,11 @@ func handleVerifyPassport(state *ServerState, w http.ResponseWriter, r *http.Req
 		IsExpired:        isExpired,
 	}
 
+	// Optionally start a face verification session bound to the DG2 portrait and
+	// return it as part of the validation result. Failures are non-fatal so that
+	// passport validation keeps working when the face service is unavailable.
+	response.FaceSession = startFaceSession(r.Context(), state, passportData.Photo, request.SessionId)
+
 	if err := writeJSON(w, http.StatusOK, response); err != nil {
 		respondWithErr(w, http.StatusInternalServerError, ErrorInternal, ERR_MARSHAL, err)
 		return
@@ -350,6 +360,31 @@ func handleVerifyPassport(state *ServerState, w http.ResponseWriter, r *http.Req
 
 	removeSessionToken(w, state.tokenStorage, request.SessionId)
 
+}
+
+// startFaceSession creates a face verification session from the DG2 portrait
+// when the integration is configured. It never fails the validation: any error
+// is logged and a nil session is returned.
+func startFaceSession(ctx context.Context, state *ServerState, portrait, sessionId string) *FaceSession {
+	if state.faceSessionCreator == nil {
+		return nil
+	}
+	if portrait == "" {
+		slog.Warn("skipping face session: no DG2 portrait available", "session_id", sessionId)
+		return nil
+	}
+
+	faceSession, err := state.faceSessionCreator.CreateSession(ctx, portrait)
+	if err != nil {
+		slog.Error("failed to create face verification session", "error", err, "session_id", sessionId)
+		return nil
+	}
+
+	slog.Info("created face verification session",
+		"session_id", sessionId,
+		"face_session_id", faceSession.FaceSessionID,
+	)
+	return faceSession
 }
 
 // handleIssueIdCard verifies and issues ID card credential

--- a/backend/server.go
+++ b/backend/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	_ "embed"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -351,7 +352,7 @@ func handleVerifyPassport(state *ServerState, w http.ResponseWriter, r *http.Req
 	// Optionally start a face verification session bound to the DG2 portrait and
 	// return it as part of the validation result. Failures are non-fatal so that
 	// passport validation keeps working when the face service is unavailable.
-	response.FaceSession = startFaceSession(r.Context(), state, passportData.Photo, request.SessionId)
+	response.FaceSession = startFaceSession(r.Context(), state, request.DataGroups, request.SessionId)
 
 	if err := writeJSON(w, http.StatusOK, response); err != nil {
 		respondWithErr(w, http.StatusInternalServerError, ErrorInternal, ERR_MARSHAL, err)
@@ -362,15 +363,17 @@ func handleVerifyPassport(state *ServerState, w http.ResponseWriter, r *http.Req
 
 }
 
-// startFaceSession creates a face verification session from the DG2 portrait
+// startFaceSession creates a face verification session bound to the DG2 portrait
 // when the integration is configured. It never fails the validation: any error
 // is logged and a nil session is returned.
-func startFaceSession(ctx context.Context, state *ServerState, portrait, sessionId string) *FaceSession {
+func startFaceSession(ctx context.Context, state *ServerState, dataGroups map[string]string, sessionId string) *FaceSession {
 	if state.faceSessionCreator == nil {
 		return nil
 	}
+
+	portrait := dg2BindingPortrait(dataGroups, sessionId)
 	if portrait == "" {
-		slog.Warn("skipping face session: no DG2 portrait available", "session_id", sessionId)
+		slog.Warn("skipping face session: no DG2 available", "session_id", sessionId)
 		return nil
 	}
 
@@ -385,6 +388,24 @@ func startFaceSession(ctx context.Context, state *ServerState, portrait, session
 		"face_session_id", faceSession.FaceSessionID,
 	)
 	return faceSession
+}
+
+// dg2BindingPortrait returns the original DG2 bytes, base64-encoded, to use as
+// the face binding reference photo. The binding key is derived from
+// SHA256(reference_photo); the mobile app derives the same key over the raw DG2
+// it read from the chip and never re-encodes it, so the issuer must send the
+// unmodified DG2 bytes here (not the converted PNG portrait).
+func dg2BindingPortrait(dataGroups map[string]string, sessionId string) string {
+	dg2Hex := dataGroups["DG2"]
+	if dg2Hex == "" {
+		return ""
+	}
+	raw, err := hex.DecodeString(dg2Hex)
+	if err != nil {
+		slog.Warn("failed to hex-decode DG2 for face binding", "error", err, "session_id", sessionId)
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(raw)
 }
 
 // handleIssueIdCard verifies and issues ID card credential

--- a/backend/server.go
+++ b/backend/server.go
@@ -58,6 +58,10 @@ type ServerState struct {
 	converter              DocumentDataConverter
 	// Optional; nil when face verification is not configured.
 	faceSessionCreator FaceSessionCreator
+	// Optional; the pull fallback that polls the face service for a result.
+	faceStatusGetter FaceSessionStatusGetter
+	// True when issuance must be gated on a successful face verification.
+	requireFaceForIssuance bool
 }
 
 type SpaHandler struct {
@@ -132,6 +136,10 @@ func NewServer(state *ServerState, config ServerConfig) (*Server, error) {
 	})
 	router.HandleFunc("/api/verify-passport", func(w http.ResponseWriter, r *http.Request) {
 		handleVerifyPassport(state, w, r)
+	})
+	// Server-to-server webhook for the face verification service's signed result.
+	router.HandleFunc("/api/face/callback", func(w http.ResponseWriter, r *http.Request) {
+		handleFaceCallback(state, w, r)
 	})
 	router.HandleFunc("/api/verify-driving-licence", func(w http.ResponseWriter, r *http.Request) {
 		handleVerifyDrivingLicence(state, w, r)
@@ -242,13 +250,17 @@ func handleVerifyDrivingLicence(state *ServerState, w http.ResponseWriter, r *ht
 		IsExpired:        isExpired,
 	}
 
+	// Optionally start a face verification session bound to the DG6 portrait.
+	// Non-fatal: validation keeps working when the face service is unavailable.
+	response.FaceSession = startFaceSession(r.Context(), state, request.DataGroups, request.SessionId)
+
 	if err := writeJSON(w, http.StatusOK, response); err != nil {
 		respondWithErr(w, http.StatusInternalServerError, ErrorInternal, ERR_MARSHAL, err)
 		return
 	}
 
-	removeSessionToken(w, state.tokenStorage, request.SessionId)
-
+	// Session intentionally NOT removed here: it is reused by the gated
+	// issue-driving-licence call, or expires via TTL.
 }
 
 // handleIssueEDL verifies and issues driving licence credential
@@ -275,6 +287,12 @@ func handleIssueEDL(state *ServerState, w http.ResponseWriter, r *http.Request) 
 
 	if err != nil {
 		respondWithErr(w, http.StatusBadRequest, "invalid request", "failed to verify driving licence", err,
+			"endpoint", endpoint, "session_id", request.SessionId)
+		return
+	}
+
+	if gerr := state.checkFaceGate(r.Context(), request); gerr != nil {
+		respondWithErr(w, gerr.code, gerr.body, "face verification gate refused issuance", gerr,
 			"endpoint", endpoint, "session_id", request.SessionId)
 		return
 	}
@@ -359,28 +377,46 @@ func handleVerifyPassport(state *ServerState, w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	removeSessionToken(w, state.tokenStorage, request.SessionId)
-
+	// The validation session is intentionally NOT removed here: the same session
+	// (and its single chip-read AA signature) is reused by the subsequent gated
+	// issue-passport call. It is consumed by issuance or expires via TTL.
 }
 
-// startFaceSession creates a face verification session bound to the DG2 portrait
-// when the integration is configured. It never fails the validation: any error
-// is logged and a nil session is returned.
+// startFaceSession creates a face verification session bound to the document's
+// face portrait (DG2 for passports/ID cards, DG6 for driving licences) when the
+// integration is configured. It never fails the validation: any error is logged
+// and a nil session is returned.
 func startFaceSession(ctx context.Context, state *ServerState, dataGroups map[string]string, sessionId string) *FaceSession {
 	if state.faceSessionCreator == nil {
 		return nil
 	}
 
-	portrait := dg2BindingPortrait(dataGroups, sessionId)
+	portrait := portraitBindingBase64(dataGroups, sessionId)
 	if portrait == "" {
-		slog.Warn("skipping face session: no DG2 available", "session_id", sessionId)
+		slog.Warn("skipping face session: no portrait data group (DG2/DG6) available", "session_id", sessionId)
 		return nil
 	}
 
-	faceSession, err := state.faceSessionCreator.CreateSession(ctx, portrait)
+	faceSession, bindingSecret, err := state.faceSessionCreator.CreateSession(ctx, portrait)
 	if err != nil {
 		slog.Error("failed to create face verification session", "error", err, "session_id", sessionId)
 		return nil
+	}
+
+	// Persist the issuer-side record so the callback can be authenticated and the
+	// verdict bound to this document's portrait at issuance time. A storage
+	// failure is non-fatal for validation, but issuance will then refuse
+	// (face:required).
+	rec := &FaceRecord{
+		FaceSessionID: faceSession.FaceSessionID,
+		SessionID:     sessionId,
+		BindingSecret: bindingSecret,
+		Dg2Sha256:     portraitSha256Hex(dataGroups),
+		Status:        faceStatusPending,
+	}
+	if err := storeFaceRecord(state.tokenStorage, rec); err != nil {
+		slog.Error("failed to store face record", "error", err, "session_id", sessionId,
+			"face_session_id", faceSession.FaceSessionID)
 	}
 
 	slog.Info("created face verification session",
@@ -390,19 +426,16 @@ func startFaceSession(ctx context.Context, state *ServerState, dataGroups map[st
 	return faceSession
 }
 
-// dg2BindingPortrait returns the original DG2 bytes, base64-encoded, to use as
-// the face binding reference photo. The binding key is derived from
-// SHA256(reference_photo); the mobile app derives the same key over the raw DG2
-// it read from the chip and never re-encodes it, so the issuer must send the
-// unmodified DG2 bytes here (not the converted PNG portrait).
-func dg2BindingPortrait(dataGroups map[string]string, sessionId string) string {
-	dg2Hex := dataGroups["DG2"]
-	if dg2Hex == "" {
-		return ""
-	}
-	raw, err := hex.DecodeString(dg2Hex)
-	if err != nil {
-		slog.Warn("failed to hex-decode DG2 for face binding", "error", err, "session_id", sessionId)
+// portraitBindingBase64 returns the original portrait data-group bytes (DG2 for
+// passports/ID cards, DG6 for driving licences), base64-encoded, to use as the
+// face binding reference photo. The binding key is derived from
+// SHA256(reference_photo); the mobile app derives the same key over the raw data
+// group it read from the chip and never re-encodes it, so the issuer must send
+// the unmodified bytes here (not the converted PNG portrait).
+func portraitBindingBase64(dataGroups map[string]string, sessionId string) string {
+	raw, ok := portraitRawBytes(dataGroups)
+	if !ok {
+		slog.Warn("no portrait data group (DG2/DG6) to bind", "session_id", sessionId)
 		return ""
 	}
 	return base64.StdEncoding.EncodeToString(raw)
@@ -432,6 +465,12 @@ func handleIssueIdCard(state *ServerState, w http.ResponseWriter, r *http.Reques
 	doc, activeAuth, request, err := VerifyPassportRequest(r, state)
 	if err != nil {
 		respondWithErr(w, http.StatusBadRequest, "invalid request", ERR_PASSPORT_VERIFICATION, err,
+			"endpoint", endpoint, "session_id", request.SessionId)
+		return
+	}
+
+	if gerr := state.checkFaceGate(r.Context(), request); gerr != nil {
+		respondWithErr(w, gerr.code, gerr.body, "face verification gate refused issuance", gerr,
 			"endpoint", endpoint, "session_id", request.SessionId)
 		return
 	}
@@ -486,6 +525,12 @@ func handleIssuePassport(state *ServerState, w http.ResponseWriter, r *http.Requ
 	doc, activeAuth, request, err := VerifyPassportRequest(r, state)
 	if err != nil {
 		respondWithErr(w, http.StatusBadRequest, "invalid request", ERR_PASSPORT_VERIFICATION, err,
+			"endpoint", endpoint, "session_id", request.SessionId)
+		return
+	}
+
+	if gerr := state.checkFaceGate(r.Context(), request); gerr != nil {
+		respondWithErr(w, gerr.code, gerr.body, "face verification gate refused issuance", gerr,
 			"endpoint", endpoint, "session_id", request.SessionId)
 		return
 	}

--- a/backend/test_helpers.go
+++ b/backend/test_helpers.go
@@ -26,7 +26,7 @@ var testConfig = ServerConfig{
 	TlsPrivKeyPath: "",
 }
 
-func startTestServer(t *testing.T, storage TokenStorage) *Server {
+func startTestServer(t *testing.T, storage TokenStorage, opts ...func(*ServerState)) *Server {
 	t.Helper()
 
 	jwtCreators := AllJwtCreators{
@@ -41,6 +41,9 @@ func startTestServer(t *testing.T, storage TokenStorage) *Server {
 		documentValidator:    fakeValidator{},
 		drivingLicenceParser: fakeEDLParser{},
 		converter:            fakeConverter{},
+	}
+	for _, o := range opts {
+		o(testState)
 	}
 
 	srv, err := NewServer(testState, testConfig)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
     restart: unless-stopped
     networks:
       - app_network
+    # Lets the container reach services published on the host (e.g. the face
+    # verification service on :8000). Resolves automatically on Docker Desktop;
+    # this mapping makes it work on Linux too.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on: [redis]
 
   redis:

--- a/docs/verification-flow-contracts.md
+++ b/docs/verification-flow-contracts.md
@@ -1,0 +1,337 @@
+# Passport Issuer — Verification Flow Contracts
+
+> Active/Passive authentication → face verification → gated credential issuance.
+> A backwards-compatibility-first proposal.
+
+This document specifies the exact wire contracts for the end-to-end issuance flow
+across the three components:
+
+- the wallet (`vcmrtd`),
+- the issuer (`go-passport-issuer`),
+- the external [`face-verification-service`](https://github.com/privacybydesign/face-verification-service).
+
+**Design goal:** passive + active authentication run **before** the face session,
+and a credential is only issued once **both** authentication and face verification
+have succeeded — while keeping every wallet-facing request/response schema unchanged.
+
+---
+
+## 1 · End-to-end sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as Wallet (vcmrtd)
+    participant I as Issuer (go-passport-issuer)
+    participant F as face-verification-service
+
+    W->>I: POST /api/start-validation
+    I->>I: store session{nonce}
+    I-->>W: { session_id, nonce }
+
+    Note over W: NFC tap (once)<br/>read DGs, sign AA over nonce
+
+    W->>I: POST /api/verify-passport<br/>{session_id, nonce, data_groups, ef_sod, aa_signature}
+    I->>I: PASSIVE auth ✓
+    I->>I: ACTIVE auth ✓
+    I->>F: POST /api/face/session<br/>{verifier_id, callback_url, portrait_image = raw DG2 b64}
+    F-->>I: {face_session_id, binding_secret, websocket_url, ...}
+    I->>I: store face{binding_secret, dg2_sha256, status: pending}<br/>session KEPT (not deleted)
+    I-->>W: {authentic_content, authentic_chip, is_expired, face_session}
+
+    Note over W,F: binding_key = HKDF(face_session_id, salt = SHA256(DG2))
+    W->>F: WebSocket handshake + stream JPEG frames
+    F-->>W: frame_result… / verification_complete{result: success}
+    F->>I: POST {callback_url}<br/>X-Face-Signature: HMAC(binding_secret)<br/>{face_session_id, result, ...}
+    I->>I: store face.status = success
+
+    W->>I: POST /api/issue-passport<br/>{session_id, nonce, data_groups, ef_sod, aa_signature, face_session_id?}
+    I->>I: PASSIVE ✓  ACTIVE ✓
+    I->>I: GATE: face.status == success<br/>AND SHA256(DG2) == face.dg2_sha256
+    I->>I: create IRMA JWT, delete session
+    I-->>W: { jwt, irma_server_url }
+
+    W->>W: POST {irma_server_url}/session → start IRMA issuance
+```
+
+Step 4 (verify) is now _optional but recommended_: the face session is created there.
+The same single NFC tap (step 2) supplies the AA signature reused by both verify and
+issue, so the session must survive from start through issue.
+
+---
+
+## 2 · Design principles
+
+- **No wallet-facing schema breaks.** `start-validation`, `verify-passport` and
+  `issue-passport` keep their existing request/response shapes. The only additive
+  field is an _optional_ `face_session_id` on issuance requests.
+- **Issuer is authoritative.** The face result is never taken from the wallet's
+  word. The issuer learns the verdict only from the face service via a
+  `binding_secret`-authenticated callback (the secret the README already reserves
+  "to authenticate result callbacks").
+- **Off-by-default stays byte-for-byte.** When `face_verification.url` is empty,
+  issuance is ungated and the whole flow behaves exactly as today.
+- **Cryptographic binding to the document.** A face verdict is only honored for
+  issuance if its reference photo hash equals `SHA256(DG2)` of the passport being
+  issued — a stolen `face_session_id` from another document cannot unlock issuance.
+- **One breaking change, scoped & safe:** the session is no longer destroyed by
+  `verify-passport`; it lives until `issue-*` consumes it (or its TTL expires).
+  No current client depends on verify being terminal.
+
+---
+
+## 3 · Endpoint contracts
+
+### `POST /api/start-validation` — UNCHANGED
+
+| Direction | Body |
+|-----------|------|
+| Request | _empty_ |
+| Response 200 | `{ "session_id": "<32 hex>", "nonce": "<16 hex>" }` |
+
+Creates the session record and the AA nonce. **Behavioral note:** the stored value
+gains internal fields (see §4) but the response is identical.
+
+---
+
+### `POST /api/verify-passport` — BEHAVIOR CHANGE (schema unchanged)
+
+Also applies to `/api/verify-driving-licence` (no face session — EDL has no DG2 portrait).
+
+```jsonc
+// Request — models.ValidationRequest (unchanged)
+{
+  "session_id": "a1b2…",
+  "nonce": "1234567890abcdef",
+  "data_groups": { "DG1": "…hex…", "DG2": "…hex…" },
+  "ef_sod": "778201ab…",
+  "aa_signature": "304502…"   // optional
+}
+```
+
+```jsonc
+// Response 200 — VerificationResponse (unchanged; face_session already present)
+{
+  "authentic_content": true,         // passive auth (signature) ok
+  "authentic_chip": true,            // active auth (chip challenge) ok
+  "is_expired": false,
+  "face_session": {                  // omitted when face disabled / no DG2
+    "face_session_id": "fs_abc123",
+    "face_session_token": "<base64url>",
+    "websocket_url": "wss://face.example/stream/fs_abc123",
+    "binding_key_ready": true
+  }
+}
+```
+
+**What changes:**
+
+- On success with face enabled + DG2 present, the issuer creates the face session
+  and **persists a face record** keyed by `face_session_id` holding
+  `{ binding_secret, dg2_sha256, status:"pending", session_id }`.
+  `binding_secret` is never returned.
+- **The session token is no longer deleted here.** It is consumed by the subsequent
+  `issue-*` call (or expires via TTL).
+- Face-service failure remains **non-fatal**: verification still returns 200 with no
+  `face_session` (unchanged).
+
+---
+
+### `POST {face_verification.callback_url}` — NEW ENDPOINT
+
+Server-to-server: the face service calls this when a session reaches a terminal
+verdict. Path is whatever `callback_url` is configured to; suggested route
+`/api/face/callback`.
+
+```http
+POST /api/face/callback
+Content-Type: application/json
+X-Face-Signature: base64( HMAC-SHA256( binding_secret, <raw request body> ) )
+```
+
+```jsonc
+// Request body
+{
+  "face_session_id": "fs_abc123",
+  "result": "success",            // "success" | "failed" | "error"
+  "match_confidence": 0.97,        // optional
+  "liveness_passed": true,         // optional
+  "frames_processed": 42,          // optional
+  "completed_at": "2026-06-19T12:00:00Z"
+}
+```
+
+```jsonc
+// Response 200
+{ "ok": true }
+```
+
+| Status | When |
+|--------|------|
+| `200` | signature valid & record updated |
+| `401` | `X-Face-Signature` missing or HMAC mismatch against the stored `binding_secret` |
+| `404` | unknown `face_session_id` |
+
+> **⚠️ External dependency.** The exact callback JSON and signature scheme must match
+> [`privacybydesign/face-verification-service`](https://github.com/privacybydesign/face-verification-service)
+> (not in this workspace). The body/headers above are the proposed contract derived
+> from the streaming protocol (`verification_complete` message fields) and the
+> README's "`binding_secret` authenticates result callbacks." Confirm field names &
+> the signature header against that repo before implementing.
+
+---
+
+### `POST /api/issue-passport` — GATED + 1 OPTIONAL FIELD
+
+Identical contract for `/api/issue-id-card`, `/api/issue-driving-licence`, and the
+legacy `/api/verify-and-issue` alias. (EDL stays ungated — no portrait.)
+
+```jsonc
+// Request — ValidationRequest + ONE optional additive field
+{
+  "session_id": "a1b2…",
+  "nonce": "1234567890abcdef",
+  "data_groups": { … },
+  "ef_sod": "…",
+  "aa_signature": "…",
+  "face_session_id": "fs_abc123"   // NEW, optional; required only when face enabled
+}
+```
+
+```jsonc
+// Response 200 — IssuanceResponse (unchanged)
+{ "jwt": "eyJhbGc…", "irma_server_url": "https://irma.example.com" }
+```
+
+**Gate (only when `face_verification.url` is configured):** after passive + active
+auth succeed, the issuer additionally requires all of:
+
+1. `face_session_id` present in the request (or resolvable from the session record — see §4 alt).
+2. a face record exists for it with `status == "success"`.
+3. `SHA256(request.data_groups["DG2"]) == face_record.dg2_sha256` — binds the verdict
+   to _this_ document.
+
+| Status | Body | When |
+|--------|------|------|
+| `200` | `{ jwt, irma_server_url }` | auth ok + (face disabled OR face gate passed) |
+| `400` | `invalid request` | bad body / session / nonce / passive / active auth fail (as today) |
+| `428` | `face:pending` | face enabled, record exists, callback not yet received → client may retry |
+| `403` | `face:required` / `face:failed` / `face:mismatch` | no face_session_id, verdict failed, or DG2 hash mismatch |
+
+On `200` the session token is removed (as today). On the gate failures the session is
+left intact so the wallet can retry after the verdict lands.
+
+---
+
+## 4 · Internal session & face state
+
+Two short-lived records in `TokenStorage` (string→string today; values become small
+JSON blobs). No interface change required — both are stored/retrieved/removed through
+the existing `StoreToken/RetrieveToken/RemoveToken`.
+
+```jsonc
+// key: <ns>:token:<session_id>   (was a bare nonce string)
+{ "nonce": "1234567890abcdef",
+  "face_session_id": "fs_abc123" }   // set by verify-passport (alt to request field)
+```
+
+```jsonc
+// key: <ns>:face:<face_session_id>   (NEW)
+{ "session_id": "a1b2…",
+  "binding_secret": "<opaque, never returned>",
+  "dg2_sha256": "<hex>",
+  "status": "pending",           // pending → success | failed | error
+  "match_confidence": null,
+  "liveness_passed": null }
+```
+
+> **Two correlation options.** _(A, recommended & zero wire change)_: store
+> `face_session_id` inside the session record at verify time, so issuance finds the
+> verdict from `session_id` alone and the request needs no new field. _(B, explicit)_:
+> the wallet passes `face_session_id` on the issue request. Implement A; accept B's
+> field as an override. Either way the DG2-hash binding (§3) is the real security check.
+
+> **⚠️ Storage value migration.** Changing the `token` value from a bare nonce to JSON
+> is the one internal break. Sessions are short-lived (24h TTL), so a deploy only
+> invalidates in-flight sessions. If you must avoid even that, keep nonce bare and
+> carry `face_session_id` only on the request (option B).
+
+---
+
+## 5 · Cryptography & binding (already implemented client-side)
+
+| Value | Definition | Who |
+|-------|------------|-----|
+| reference photo | the **raw DG2 bytes** read from the chip, base64-encoded as `portrait_image` | issuer → face svc |
+| `binding_key` | `HKDF-SHA256(ikm=face_session_id, salt=SHA256(reference_photo), info="yivi_face_binding_v1")` | wallet ↔ face svc |
+| WS handshake | `HMAC-SHA256(binding_key, face_session_id)` | wallet → face svc |
+| frame MAC | `HMAC-SHA256(binding_key, frame_bytes ‖ seq_be64)` | wallet → face svc |
+| `binding_secret` | issuer↔face shared secret; authenticates the **callback** (distinct from binding_key) | issuer ↔ face svc |
+| issuance binding | `SHA256(DG2)` must match on both the face session (created in verify) and the issue request | issuer-internal |
+
+Because the binding key is salted with `SHA256(raw DG2)`, only the wallet that
+physically read the chip can stream against the session — and only that same chip's
+portrait can later satisfy the issuance gate.
+
+```mermaid
+flowchart LR
+    DG2["raw DG2 bytes"] -->|SHA256| SALT["salt"]
+    FSID["face_session_id"] -->|ikm| HKDF
+    SALT -->|salt| HKDF["HKDF-SHA256<br/>info: yivi_face_binding_v1"]
+    HKDF --> BK["binding_key (32B)"]
+    BK -->|"HMAC(face_session_id)"| HS["WS handshake"]
+    BK -->|"HMAC(frame ‖ seq)"| FM["frame MAC"]
+    DG2 -->|SHA256| H1["dg2_sha256 @ verify"]
+    DG2B["DG2 @ issue"] -->|SHA256| H2["dg2_sha256 @ issue"]
+    H1 -.must equal.-> H2
+```
+
+---
+
+## 6 · Config additions
+
+```jsonc
+{
+  "face_verification": {
+    "url": "https://face.example.com",        // empty ⇒ disabled, flow unchanged
+    "verifier_id": "passport-issuer",
+    "callback_url": "https://issuer.example.com/api/face/callback",
+    "timeout_seconds": 10,
+    "require_face_for_issuance": true    // NEW, default true when url set; false ⇒ face advisory only
+  }
+}
+```
+
+`require_face_for_issuance:false` lets an operator run face verification as
+informational (start the session, surface the result) without hard-gating issuance —
+useful for staged rollout.
+
+---
+
+## 7 · Backwards-compatibility matrix
+
+| Surface | Face disabled (default) | Face enabled |
+|---------|-------------------------|--------------|
+| `start-validation` req/resp | identical | identical |
+| `verify-passport` req/resp | identical | identical (+ face_session, already shipped) |
+| session lifecycle | not deleted at verify | not deleted at verify |
+| `issue-*` request | identical | + optional `face_session_id` |
+| `issue-*` behavior | ungated — as today | gated on face verdict |
+| `/api/face/callback` | n/a | new server-to-server route |
+| token storage value | nonce → JSON (opt A) | nonce → JSON (opt A) |
+
+---
+
+## 8 · Open questions to confirm
+
+1. **Callback schema & signature** — exact field names and the HMAC header/format
+   must be read from `face-verification-service` (not in this workspace).
+   Everything else keys off this.
+2. **Pending-verdict UX** — `428 face:pending` + client retry (proposed) vs. a short
+   server-side wait vs. a `GET /api/face/result` poll endpoint. The wallet already
+   knows the verdict from the WebSocket, so it only issues after local success; the
+   issuer just needs the callback to have landed.
+3. **Correlation option** — A (session-record link, zero wire change) vs. B (explicit
+   request field). Recommend A with B as override.
+4. **ID card** — same gate as passport (it carries DG2); confirm the product intent
+   that ID cards also require face verification.

--- a/docs/verification-flow-contracts.md
+++ b/docs/verification-flow-contracts.md
@@ -96,7 +96,8 @@ gains internal fields (see §4) but the response is identical.
 
 ### `POST /api/verify-passport` — BEHAVIOR CHANGE (schema unchanged)
 
-Also applies to `/api/verify-driving-licence` (no face session — EDL has no DG2 portrait).
+Also applies to `/api/verify-driving-licence`, which starts a face session bound to the
+eDL's **DG6** portrait (passports/ID cards use **DG2**).
 
 ```jsonc
 // Request — models.ValidationRequest (unchanged)
@@ -140,24 +141,33 @@ Also applies to `/api/verify-driving-licence` (no face session — EDL has no DG
 ### `POST {face_verification.callback_url}` — NEW ENDPOINT
 
 Server-to-server: the face service calls this when a session reaches a terminal
-verdict. Path is whatever `callback_url` is configured to; suggested route
-`/api/face/callback`.
+verdict. The issuer registers it at `POST /api/face/callback`; point
+`face_verification.callback_url` at that path.
+
+The signature is carried **in the body** as a `signature` field — a hex-encoded
+`HMAC-SHA256(binding_secret, canonical_json)` where `canonical_json` is the body
+**without** the `signature` field, serialized with sorted keys and compact
+separators (Python `json.dumps(payload, sort_keys=True, separators=(",", ":"))`).
 
 ```http
 POST /api/face/callback
 Content-Type: application/json
-X-Face-Signature: base64( HMAC-SHA256( binding_secret, <raw request body> ) )
 ```
 
 ```jsonc
 // Request body
 {
   "face_session_id": "fs_abc123",
-  "result": "success",            // "success" | "failed" | "error"
-  "match_confidence": 0.97,        // optional
-  "liveness_passed": true,         // optional
-  "frames_processed": 42,          // optional
-  "completed_at": "2026-06-19T12:00:00Z"
+  "result": "success",                 // "success" | "failed" | "error"
+  "timestamp": "2026-06-19T12:00:00+00:00",
+  "details": {
+    "match_confidence": 0.97,
+    "liveness_passed": true,
+    "liveness_score": 0.9,
+    "frames_processed": 42,
+    "verification_duration_ms": 1234
+  },
+  "signature": "<hex HMAC-SHA256 over canonical JSON, keyed by binding_secret>"
 }
 ```
 
@@ -169,22 +179,25 @@ X-Face-Signature: base64( HMAC-SHA256( binding_secret, <raw request body> ) )
 | Status | When |
 |--------|------|
 | `200` | signature valid & record updated |
-| `401` | `X-Face-Signature` missing or HMAC mismatch against the stored `binding_secret` |
+| `400` | malformed body / missing `face_session_id` |
+| `401` | `signature` missing or HMAC mismatch against the stored `binding_secret` |
 | `404` | unknown `face_session_id` |
 
-> **⚠️ External dependency.** The exact callback JSON and signature scheme must match
+> **Verified against the service.** This matches
 > [`privacybydesign/face-verification-service`](https://github.com/privacybydesign/face-verification-service)
-> (not in this workspace). The body/headers above are the proposed contract derived
-> from the streaming protocol (`verification_complete` message fields) and the
-> README's "`binding_secret` authenticates result callbacks." Confirm field names &
-> the signature header against that repo before implementing.
+> (`backend/services/callback_service.py`): the verdict nests under `details`, the
+> `signature` is hex over canonical sorted/compact JSON of the unsigned body, and
+> delivery is a background webhook with retries when `callback_url` was supplied at
+> session creation. The Go receiver reproduces the canonical form via `json.Number`
+> (preserving integral floats like `1.0`) with HTML-escaping disabled.
 
 ---
 
 ### `POST /api/issue-passport` — GATED + 1 OPTIONAL FIELD
 
 Identical contract for `/api/issue-id-card`, `/api/issue-driving-licence`, and the
-legacy `/api/verify-and-issue` alias. (EDL stays ungated — no portrait.)
+legacy `/api/verify-and-issue` alias. All document types are gated when face
+verification is required: passports/ID cards bind on **DG2**, driving licences on **DG6**.
 
 ```jsonc
 // Request — ValidationRequest + ONE optional additive field
@@ -225,19 +238,19 @@ left intact so the wallet can retry after the verdict lands.
 
 ## 4 · Internal session & face state
 
-Two short-lived records in `TokenStorage` (string→string today; values become small
-JSON blobs). No interface change required — both are stored/retrieved/removed through
-the existing `StoreToken/RetrieveToken/RemoveToken`.
+The validation-session value is **unchanged** (a bare nonce). The face record is a
+new, separate keyspace. Both go through the existing
+`StoreToken/RetrieveToken/RemoveToken` — no interface change.
 
 ```jsonc
-// key: <ns>:token:<session_id>   (was a bare nonce string)
-{ "nonce": "1234567890abcdef",
-  "face_session_id": "fs_abc123" }   // set by verify-passport (alt to request field)
+// key: <ns>:token:<session_id>   (UNCHANGED — still a bare nonce string)
+"1234567890abcdef"
 ```
 
 ```jsonc
-// key: <ns>:face:<face_session_id>   (NEW)
-{ "session_id": "a1b2…",
+// key: <ns>:token:facerec:<face_session_id>   (NEW)
+{ "face_session_id": "fs_abc123",
+  "session_id": "a1b2…",
   "binding_secret": "<opaque, never returned>",
   "dg2_sha256": "<hex>",
   "status": "pending",           // pending → success | failed | error
@@ -245,16 +258,16 @@ the existing `StoreToken/RetrieveToken/RemoveToken`.
   "liveness_passed": null }
 ```
 
-> **Two correlation options.** _(A, recommended & zero wire change)_: store
-> `face_session_id` inside the session record at verify time, so issuance finds the
-> verdict from `session_id` alone and the request needs no new field. _(B, explicit)_:
-> the wallet passes `face_session_id` on the issue request. Implement A; accept B's
-> field as an override. Either way the DG2-hash binding (§3) is the real security check.
+> **Correlation: option B (implemented).** The wallet passes `face_session_id` on the
+> issue request; the issuer looks up the `facerec:` record and enforces the
+> `SHA256(DG2)` binding. The nonce-keyed session value is untouched, so `validateSession`
+> and the storage backends are unchanged. (Option A — embedding `face_session_id` in
+> the session record for zero wire change — remains a valid alternative, but B keeps
+> the security-critical check, the DG2 hash, explicit and avoids migrating the stored
+> nonce format.)
 
-> **⚠️ Storage value migration.** Changing the `token` value from a bare nonce to JSON
-> is the one internal break. Sessions are short-lived (24h TTL), so a deploy only
-> invalidates in-flight sessions. If you must avoid even that, keep nonce bare and
-> carry `face_session_id` only on the request (option B).
+> **No storage migration.** Because option B keeps the nonce value bare, there is no
+> change to existing session records and nothing to migrate across a deploy.
 
 ---
 
@@ -318,20 +331,27 @@ useful for staged rollout.
 | `issue-*` request | identical | + optional `face_session_id` |
 | `issue-*` behavior | ungated — as today | gated on face verdict |
 | `/api/face/callback` | n/a | new server-to-server route |
-| token storage value | nonce → JSON (opt A) | nonce → JSON (opt A) |
+| token storage value (nonce) | unchanged (bare nonce) | unchanged (bare nonce) |
+| token storage (new keyspace) | n/a | `facerec:<id>` JSON record |
 
 ---
 
-## 8 · Open questions to confirm
+## 8 · Resolved decisions (as implemented)
 
-1. **Callback schema & signature** — exact field names and the HMAC header/format
-   must be read from `face-verification-service` (not in this workspace).
-   Everything else keys off this.
-2. **Pending-verdict UX** — `428 face:pending` + client retry (proposed) vs. a short
-   server-side wait vs. a `GET /api/face/result` poll endpoint. The wallet already
-   knows the verdict from the WebSocket, so it only issues after local success; the
-   issuer just needs the callback to have landed.
-3. **Correlation option** — A (session-record link, zero wire change) vs. B (explicit
-   request field). Recommend A with B as override.
-4. **ID card** — same gate as passport (it carries DG2); confirm the product intent
-   that ID cards also require face verification.
+1. **Callback schema & signature** — ✅ confirmed against
+   `face-verification-service`: in-body hex `signature` over canonical sorted/compact
+   JSON, verdict under `details` (see §3). The Go receiver reproduces the canonical
+   form with `json.Number` + HTML-escaping disabled.
+2. **Pending-verdict UX** — implemented as **both**: `428 face:pending` is returned
+   only when the verdict is genuinely not yet known *and* no status poll is wired.
+   When `faceStatusGetter` is configured the issuer first pulls
+   `GET /api/face/session/{id}/status` as a synchronous fallback, so the wallet
+   normally needs no retry.
+3. **Correlation option** — implemented **option B**: the wallet passes
+   `face_session_id` on the issue request; the nonce-keyed session value is left
+   unchanged. The face record (binding_secret, `dg2_sha256`, status) lives in a
+   separate `facerec:<id>` keyspace. The `SHA256(DG2)` binding is the security check.
+4. **ID card & driving licence** — gated identically to passport. ID cards bind on
+   DG2 (same eMRTD path as passports); driving licences bind on DG6. The face
+   service extracts the embedded JPEG/JPEG2000 from either container, so the
+   binding stays over the raw data-group bytes on both sides.


### PR DESCRIPTION
## Summary

Implements the issuer side of the [face-verification-service](https://github.com/privacybydesign/face-verification-service) flow for **all supported MRTDs** — passports, ID cards, and driving licences (eDL).

The issuer can now:

1. **Start a face session during validation** (`verify-*`): after authenticating the chip, it POSTs the document portrait to a **configurable** face verification endpoint and returns the session so the wallet can connect to the live stream (the wallet derives the same binding key from the portrait bytes it already holds).
2. **Receive the signed result** (`POST /api/face/callback`): verifies the in-body HMAC against the session `binding_secret` and records the verdict.
3. **Gate credential issuance** (`issue-*`): passport, ID-card, and driving-licence issuance is held until a successful, document-bound face verification, with a status-poll fallback when the pushed callback has not yet arrived.

## Binding correctness

The binding key is `HKDF(salt = SHA256(reference_photo))`. The mobile app derives it over the **raw portrait bytes** it read over NFC and does not re-encode the image, so the issuer sends the **original, unmodified bytes** (base64) as `portrait_image` — not a converted PNG. Both sides therefore hash identical bytes and the handshake succeeds.

The portrait source is per document type:

- **Passport / ID card** — DG2
- **Driving licence (eDL)** — DG6

The same bytes are hashed at issuance time and compared against the stored face record, so a verdict for one document can never authorise issuance of another.

## Backwards compatibility

The integration is **opt-in via config** and existing deployments are unaffected:

- **No `face_verification.url` configured (every existing deployment): behaviour is byte-for-byte identical to before.** The client is nil, so no face session is started, `face_session` is never added to the validation response, and `checkFaceGate` short-circuits — issuance is never gated.
- `face_session` is a new **optional** (`omitempty`) field on the validation response; clients see no change when the feature is disabled.
- Session creation during `verify-*` is **non-fatal**: a face-service error is logged and validation still succeeds with no `face_session`.
- The face service's `binding_secret` (used to authenticate result callbacks) is intentionally **never exposed** to callers.

**Behavioural note when enabled:** once `face_verification.url` is set, issuance gating defaults to **on** (`require_face_for_issuance` defaults to `true` when omitted). A deployment that wants the session/streaming feature **without** blocking issuance must opt out explicitly:

```json
"face_verification": { "url": "...", "require_face_for_issuance": false }
```

In that advisory mode, sessions are started and results recorded, but issuance is not blocked.

## Gate responses

When gating is active, `issue-*` returns a reason string so the wallet can react:

- `face:required` — no/unknown face session for this issuance
- `face:mismatch` — the session's portrait hash does not match this document
- `face:pending` (`428 Precondition Required`) — verdict not in yet; retry
- `face:failed` (`403 Forbidden`) — verification did not pass

## Changes

- `face_verification.go` — `FaceSessionCreator` / `FaceSessionStatusGetter` interfaces + HTTP client that POSTs the reference photo to `{url}/api/face/session`, with timeout, status/error handling, and response-size limit.
- `face_callback.go` — `POST /api/face/callback` receiver (HMAC verification against `binding_secret`), per-session face record persistence (binding secret, portrait hash, status), and the issuance gate with status-poll fallback.
- `Config` gains a `face_verification` block (`url`, `verifier_id`, `callback_url`, `timeout_seconds`, `require_face_for_issuance`); wired into `ServerState` (kept as a nil interface when unconfigured to avoid the typed-nil gotcha).
- `verify-*` builds the reference photo from the original DG2 (passport/ID) or DG6 (eDL) bytes, starts the session, and attaches it to the response; `issue-*` enforces the gate.
- `models` — validation request carries `face_session_id` to bind issuance to the session.
- Regenerated swagger docs; added `docs/verification-flow-contracts.md`; documented the config block in the README; `docker-compose.yml` gains a `host.docker.internal` mapping for host-published services.

## Configuration

```json
{
  "face_verification": {
    "url": "https://face.example.com",
    "verifier_id": "passport-issuer",
    "callback_url": "https://issuer.example.com/api/face/callback",
    "timeout_seconds": 10,
    "require_face_for_issuance": true
  }
}
```
