### PR TITLE
feat: log detected DG2 image format on decode failure

### DIFF
--- a/backend/images/converter.go
+++ b/backend/images/converter.go
@@ -121,7 +121,7 @@ func decodeImage(data []byte) (image.Image, error) {
 		return img, nil
 	}
 
-	return nil, fmt.Errorf("unsupported or invalid image format (detected:%q recognized:%t prefix:%x)",
+	return nil, fmt.Errorf("unsupported or invalid image format (detected:%q recognized:%t prefix:%s)",
 		detected, known, prefix)
 }
 

--- a/backend/images/converter.go
+++ b/backend/images/converter.go
@@ -101,10 +101,19 @@ func decodeImage(data []byte) (image.Image, error) {
 	if jp2Err == nil {
 		return img, nil
 	}
-	slog.Warn("JPEG2000 decode failed",
-		"detected_format", detected,
-		"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)),
-		"error", jp2Err)
+	// imagick sniffs the blob rather than trusting the caller, so this branch also
+	// swallows non-JPEG2000 payloads; only blame JPEG2000 when the magic bytes did.
+	if detected == utils.ImageFormatJPEG2000 {
+		slog.Warn("JPEG2000 decode failed",
+			"detected_format", detected,
+			"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)),
+			"error", jp2Err)
+	} else {
+		slog.Debug("imagick decode failed and payload is not JPEG2000",
+			"detected_format", detected,
+			"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)),
+			"error", jp2Err)
+	}
 
 	// Try generic image decode as fallback
 	if img, _, err := image.Decode(bytes.NewReader(data)); err == nil {

--- a/backend/images/converter.go
+++ b/backend/images/converter.go
@@ -107,12 +107,12 @@ func decodeImage(data []byte) (image.Image, error) {
 	if detected == utils.ImageFormatJPEG2000 {
 		slog.Warn("JPEG2000 decode failed",
 			"detected_format", detected,
-			"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)),
+			"prefix", prefix,
 			"error", jp2Err)
 	} else {
 		slog.Debug("imagick decode failed and payload is not JPEG2000",
 			"detected_format", detected,
-			"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)),
+			"prefix", prefix,
 			"error", jp2Err)
 	}
 
@@ -122,7 +122,7 @@ func decodeImage(data []byte) (image.Image, error) {
 	}
 
 	return nil, fmt.Errorf("unsupported or invalid image format (detected:%q recognized:%t prefix:%x)",
-		detected, known, utils.SafePrefix(data, 12))
+		detected, known, prefix)
 }
 
 // convertImageToPNGBase64 encodes an image to base64 PNG with optional resize and quantization

--- a/backend/images/converter.go
+++ b/backend/images/converter.go
@@ -83,8 +83,8 @@ func RawDG2ImageBase64(dg2 *document.DG2) (string, error) {
 func decodeImage(data []byte) (image.Image, error) {
 	// Detect the on-wire format from magic bytes before attempting to decode, so
 	// failures below can report *which* format arrived instead of an opaque error.
-	// gmrtd's detector recognizes both JP2 container (00 00 00 0C 6A 50 20 20)
-	// and raw J2K codestream (FF 4F FF 51) encodings.
+	// gmrtd's detector recognizes both the JP2 container (00 00 00 0C 6A 50 20 20 0D 0A —
+	// note it requires the 0D 0A too) and the raw J2K codestream (FF 4F FF 51) encodings.
 	detected, known := utils.DetectImageFormat(data)
 	slog.Debug("Detected DG2 image format",
 		"detected_format", detected,

--- a/backend/images/converter.go
+++ b/backend/images/converter.go
@@ -97,14 +97,14 @@ func decodeImage(data []byte) (image.Image, error) {
 	}
 
 	// Try JPEG 2000 (JP2/J2K)
-	if img, err := jpeg2000.Parse(data); err == nil {
+	img, jp2Err := jpeg2000.Parse(data)
+	if jp2Err == nil {
 		return img, nil
-	} else {
-		slog.Warn("JPEG2000 decode failed",
-			"detected_format", detected,
-			"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)),
-			"error", err)
 	}
+	slog.Warn("JPEG2000 decode failed",
+		"detected_format", detected,
+		"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)),
+		"error", jp2Err)
 
 	// Try generic image decode as fallback
 	if img, _, err := image.Decode(bytes.NewReader(data)); err == nil {

--- a/backend/images/converter.go
+++ b/backend/images/converter.go
@@ -86,10 +86,11 @@ func decodeImage(data []byte) (image.Image, error) {
 	// gmrtd's detector recognizes both the JP2 container (00 00 00 0C 6A 50 20 20 0D 0A —
 	// note it requires the 0D 0A too) and the raw J2K codestream (FF 4F FF 51) encodings.
 	detected, known := utils.DetectImageFormat(data)
+	prefix := fmt.Sprintf("%x", utils.SafePrefix(data, 12))
 	slog.Debug("Detected DG2 image format",
 		"detected_format", detected,
 		"recognized", known,
-		"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)))
+		"prefix", prefix)
 
 	// Try JPEG first (most common)
 	if img, err := jpeg.Decode(bytes.NewReader(data)); err == nil {

--- a/backend/images/converter.go
+++ b/backend/images/converter.go
@@ -13,6 +13,7 @@ import (
 	"math"
 
 	"github.com/gmrtd/gmrtd/document"
+	"github.com/gmrtd/gmrtd/utils"
 	xdraw "golang.org/x/image/draw"
 	"pault.ag/go/cbeff/jpeg2000"
 )
@@ -80,6 +81,16 @@ func RawDG2ImageBase64(dg2 *document.DG2) (string, error) {
 
 // decodeImage attempts to decode an image from bytes, trying multiple formats
 func decodeImage(data []byte) (image.Image, error) {
+	// Detect the on-wire format from magic bytes before attempting to decode, so
+	// failures below can report *which* format arrived instead of an opaque error.
+	// gmrtd's detector recognizes both JP2 container (00 00 00 0C 6A 50 20 20)
+	// and raw J2K codestream (FF 4F FF 51) encodings.
+	detected, known := utils.DetectImageFormat(data)
+	slog.Debug("Detected DG2 image format",
+		"detected_format", detected,
+		"recognized", known,
+		"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)))
+
 	// Try JPEG first (most common)
 	if img, err := jpeg.Decode(bytes.NewReader(data)); err == nil {
 		return img, nil
@@ -88,6 +99,11 @@ func decodeImage(data []byte) (image.Image, error) {
 	// Try JPEG 2000 (JP2/J2K)
 	if img, err := jpeg2000.Parse(data); err == nil {
 		return img, nil
+	} else {
+		slog.Warn("JPEG2000 decode failed",
+			"detected_format", detected,
+			"prefix", fmt.Sprintf("%x", utils.SafePrefix(data, 12)),
+			"error", err)
 	}
 
 	// Try generic image decode as fallback
@@ -95,7 +111,8 @@ func decodeImage(data []byte) (image.Image, error) {
 		return img, nil
 	}
 
-	return nil, fmt.Errorf("unsupported or invalid image format")
+	return nil, fmt.Errorf("unsupported or invalid image format (detected:%q recognized:%t prefix:%x)",
+		detected, known, utils.SafePrefix(data, 12))
 }
 
 // convertImageToPNGBase64 encodes an image to base64 PNG with optional resize and quantization

--- a/backend/images/converter_test.go
+++ b/backend/images/converter_test.go
@@ -3,6 +3,7 @@ package images
 import (
 	"image"
 	"image/png"
+	"strings"
 	"testing"
 
 	"github.com/gmrtd/gmrtd/document"
@@ -102,11 +103,20 @@ func TestDecodeImage_InvalidData(t *testing.T) {
 	invalidData := []byte{0x00, 0x01, 0x02, 0x03}
 	_, err := decodeImage(invalidData)
 	if err == nil {
-		t.Error("Expected error with invalid image data, got nil")
+		t.Fatal("Expected error with invalid image data, got nil")
 	}
-	expectedMsg := "unsupported or invalid image format"
-	if err.Error() != expectedMsg {
-		t.Errorf("Expected error '%s', got '%s'", expectedMsg, err.Error())
+	// The diagnostic fields are the point of this path: an unrecognized payload
+	// must surface its (empty) detected format and magic-byte prefix to the caller.
+	msg := err.Error()
+	for _, want := range []string{
+		"unsupported or invalid image format",
+		`detected:""`,
+		"recognized:false",
+		"prefix:00010203",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Expected error to contain %q, got %q", want, msg)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

DG2 face-image conversion fails with an opaque error that gives no way to tell *why*:

```
failed to convert DG2 images to PNG: failed to decode image 0: unsupported or invalid image format
```

This makes it impossible to distinguish a JPEG2000 the decoder genuinely can't handle from a non-image payload, or to tell a JP2 container apart from a raw J2K codestream.

## Change

`decodeImage` now uses gmrtd's `utils.DetectImageFormat` (already a dependency via v1.0.0) to:

- Log the detected format and the first 12 magic bytes **before** attempting to decode.
- Emit a WARN with the underlying imagick error when the JPEG2000 path fails, including the detected format and prefix.
- Carry the detected format, recognition flag, and byte prefix into the **final** error message instead of the bare string.

The magic-byte prefix pins the cause on the next failure:

| Prefix | Meaning |
|---|---|
| `ffd8ff…` | Baseline JPEG |
| `0000000c6a502020…` | JP2 container |
| `ff4fff51…` | Raw J2K codestream (imagick blob sniffing is unreliable here) |
| other | Not a valid image / upstream parsing issue |

Diagnostic-only; no behavioural change to successful conversions.