### PR TITLE
chore: point gmrtd dependency to privacybydesign soft fork

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -124,3 +124,5 @@ require (
 // subpackage typecheck. A `replace` (rather than `exclude`) keeps the pin solid
 // against future v2.7.x releases. Remove once cbeff is updated.
 replace gopkg.in/gographics/imagick.v2 => gopkg.in/gographics/imagick.v2 v2.6.4
+
+replace github.com/gmrtd/gmrtd => github.com/privacybydesign/gmrtd v1.0.1-0.20260805100725-2a69bd85e976

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -125,4 +125,4 @@ require (
 // against future v2.7.x releases. Remove once cbeff is updated.
 replace gopkg.in/gographics/imagick.v2 => gopkg.in/gographics/imagick.v2 v2.6.4
 
-replace github.com/gmrtd/gmrtd => github.com/privacybydesign/gmrtd v1.0.1-0.20260805100725-2a69bd85e976
+replace github.com/gmrtd/gmrtd => github.com/privacybydesign/gmrtd v1.0.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -75,8 +75,6 @@ github.com/fxamacker/cbor v1.5.1 h1:XjQWBgdmQyqimslUh5r4tUGmoqzHmBFQOImkWGi2awg=
 github.com/fxamacker/cbor v1.5.1/go.mod h1:3aPGItF174ni7dDzd6JZ206H8cmr4GDNBGpPa971zsU=
 github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gmrtd/gmrtd v0.48.0 h1:9q/yr+ufSGyC9+rCa6iQKWAAe+UDZ11KOCv19u2Em9U=
-github.com/gmrtd/gmrtd v0.48.0/go.mod h1:VX8wI8NBJgy+EwFO2Svmxr25bioQsQOfiqy/dr6/XOc=
 github.com/go-co-op/gocron v1.37.0 h1:ZYDJGtQ4OMhTLKOKMIch+/CY70Brbb1dGdooLEhh7b0=
 github.com/go-co-op/gocron v1.37.0/go.mod h1:3L/n6BkO7ABj+TrfSVXLRzsP26zmikL4ISkLQ0O8iNY=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
@@ -247,6 +245,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/privacybydesign/gabi v0.0.0-20260519111214-f8484462b684 h1:en00INqhAmeJ34gRL1PqlUP9U1C7ZMX09zyHnPFZEVc=
 github.com/privacybydesign/gabi v0.0.0-20260519111214-f8484462b684/go.mod h1:yPSrEdlOxupU/VVhhbdu7a0adFTq8a2SpOaC4BXCXQc=
+github.com/privacybydesign/gmrtd v1.0.1-0.20260805100725-2a69bd85e976 h1:zNv0nZwymN5InUEIVIgKf4IstpPzNk4V+WC3KLfyGAY=
+github.com/privacybydesign/gmrtd v1.0.1-0.20260805100725-2a69bd85e976/go.mod h1:VX8wI8NBJgy+EwFO2Svmxr25bioQsQOfiqy/dr6/XOc=
 github.com/privacybydesign/irmago v1.1.0 h1:Bs9YyCCykb2wMg6PhN8FfJ/YnBlvkvDoQ0hk+ziZSx4=
 github.com/privacybydesign/irmago v1.1.0/go.mod h1:h8Cnwbfj8s5lKKIURMMVBsssKQtGjisant9+LewK0Lg=
 github.com/redis/go-redis/v9 v9.21.0 h1:FPBE4hhbAke+TLmcY3WkpbDffJEomdqPn3HYiqAtL9E=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -245,8 +245,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/privacybydesign/gabi v0.0.0-20260519111214-f8484462b684 h1:en00INqhAmeJ34gRL1PqlUP9U1C7ZMX09zyHnPFZEVc=
 github.com/privacybydesign/gabi v0.0.0-20260519111214-f8484462b684/go.mod h1:yPSrEdlOxupU/VVhhbdu7a0adFTq8a2SpOaC4BXCXQc=
-github.com/privacybydesign/gmrtd v1.0.1-0.20260805100725-2a69bd85e976 h1:zNv0nZwymN5InUEIVIgKf4IstpPzNk4V+WC3KLfyGAY=
-github.com/privacybydesign/gmrtd v1.0.1-0.20260805100725-2a69bd85e976/go.mod h1:VX8wI8NBJgy+EwFO2Svmxr25bioQsQOfiqy/dr6/XOc=
+github.com/privacybydesign/gmrtd v1.0.1 h1:Bq3ABFaskIa20rglwbvKuzea8kiEwyRMZSN6AzAwcC0=
+github.com/privacybydesign/gmrtd v1.0.1/go.mod h1:VX8wI8NBJgy+EwFO2Svmxr25bioQsQOfiqy/dr6/XOc=
 github.com/privacybydesign/irmago v1.1.0 h1:Bs9YyCCykb2wMg6PhN8FfJ/YnBlvkvDoQ0hk+ziZSx4=
 github.com/privacybydesign/irmago v1.1.0/go.mod h1:h8Cnwbfj8s5lKKIURMMVBsssKQtGjisant9+LewK0Lg=
 github.com/redis/go-redis/v9 v9.21.0 h1:FPBE4hhbAke+TLmcY3WkpbDffJEomdqPn3HYiqAtL9E=


### PR DESCRIPTION
Redirects the `github.com/gmrtd/gmrtd` dependency to our soft fork at [privacybydesign/gmrtd](https://github.com/privacybydesign/gmrtd).

## What changed
- Added a `replace` directive in `backend/go.mod` pointing `github.com/gmrtd/gmrtd` → `github.com/privacybydesign/gmrtd`, pinned to the current tip of the fork's `main`.
- Updated `backend/go.sum` with the fork's checksums.

## Why a replace directive
The fork retains the original module path (`module github.com/gmrtd/gmrtd`), so every existing import resolves to the fork with **no source changes required**.

## Bumping the fork later
When new commits land on the fork, run from `backend/`:
```
go get github.com/privacybydesign/gmrtd@main && go mod tidy
```